### PR TITLE
Change Proxy WSDL URL validator to allow localhost

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.artifact.proxyservice/src/org/wso2/integrationstudio/artifact/proxyservice/model/ProxyServiceModel.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.artifact.proxyservice/src/org/wso2/integrationstudio/artifact/proxyservice/model/ProxyServiceModel.java
@@ -246,7 +246,7 @@ public class ProxyServiceModel extends ProjectDataModel {
             String url = (String) data;
             if (StringUtils.isNotBlank(url)) {
                 setProxyWSDLurl(url);
-                UrlValidator urlValidator = new UrlValidator();
+                UrlValidator urlValidator = new UrlValidator(UrlValidator.ALLOW_LOCAL_URLS);
                 if (urlValidator.isValid(url)) {
                     addAvailableNames(url);
                 }


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Currently, URL validator does not accept localhost as a proper valid URL.

Resolves wso2/devstudio-tooling-ei#1317