### PR TITLE
Refactor API creation from swagger definition path

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.artifact.synapse.api/project_wizard.xml
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.artifact.synapse.api/project_wizard.xml
@@ -71,14 +71,14 @@
 				<data modelProperty="swagger.api.name" type="string"
 				fieldController="org.wso2.integrationstudio.artifact.synapse.api.validator.ProjectFieldController">API Name*</data>
 			<group id ="location"/>
-			<!-- <data modelProperty="swagger.reg.location" type="workspacefolder" fieldController="org.wso2.integrationstudio.artifact.synapse.api.validator.ProjectFieldController" 
-			controlData="filterClass=org.wso2.integrationstudio.artifact.synapse.api.validator.RegistryProjectFilter" >Swagger Registry Path </data>
-			<data modelProperty="create.reg.prj" type="link" fieldController="org.wso2.integrationstudio.artifact.synapse.api.validator.ProjectFieldController" 
-			controlData="align=right" >&lt;a&gt;Create new Project...&lt;/a&gt;</data> -->
+			<data group="location" modelProperty="swagger.reg.location" type="workspacefolder" fieldController="org.wso2.integrationstudio.artifact.synapse.api.validator.ProjectFieldController" 
+			controlData="filterClass=org.wso2.integrationstudio.artifact.synapse.api.validator.RegistryProjectFilter" >Save Registry Path:</data>
+			<data group="location" modelProperty="create.reg.prj" type="link" fieldController="org.wso2.integrationstudio.artifact.synapse.api.validator.ProjectFieldController" 
+			controlData="align=right" >&lt;a&gt;Create new Project...&lt;/a&gt;</data>
 			<data modelProperty="save.location" type="workspacefolder"
 				fieldController="org.wso2.integrationstudio.artifact.synapse.api.validator.ProjectFieldController"
 				group="location"
-				controlData="filterClass=org.wso2.integrationstudio.artifact.synapse.api.validator.ESBProjectFilter">Save location:</data>
+				controlData="filterClass=org.wso2.integrationstudio.artifact.synapse.api.validator.ESBProjectFilter">Save Location:</data>
 			<data modelProperty="create.esb.prj" type="link"
 				fieldController="org.wso2.integrationstudio.artifact.synapse.api.validator.ProjectFieldController"
 				group="location"

--- a/components/esb-tools/plugins/org.wso2.integrationstudio.artifact.synapse.api/src/org/wso2/integrationstudio/artifact/synapse/api/validator/ProjectFieldController.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.artifact.synapse.api/src/org/wso2/integrationstudio/artifact/synapse/api/validator/ProjectFieldController.java
@@ -102,7 +102,8 @@ public class ProjectFieldController extends AbstractFieldController {
 	public boolean isReadOnlyField(String modelProperty, ProjectDataModel model) {
 		boolean readOnlyField = super.isReadOnlyField(modelProperty, model);
 		if (modelProperty.equals(ArtifactConstants.ID_SAVE_LOCATION) 
-		        || modelProperty.equals(ArtifactConstants.ID_API_SWAGGER_FILE)) {
+		        || modelProperty.equals(ArtifactConstants.ID_API_SWAGGER_FILE)
+		        || modelProperty.equals(ArtifactConstants.ID_SWAGGER_FILE_REGISTRY_LOCATION)) {
 			readOnlyField = true;
 		}
 	    return readOnlyField;


### PR DESCRIPTION
## Purpose
> $subject

- Add registry path for generating API from a swagger wizard
- Persists swagger sources when saving from the design or source views