### PR TITLE
Fix encode issue in Uri template in HTTP Endpoint 

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.persistence/src/org/wso2/integrationstudio/gmf/esb/internal/persistence/HTTPEndPointTransformer.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.persistence/src/org/wso2/integrationstudio/gmf/esb/internal/persistence/HTTPEndPointTransformer.java
@@ -128,7 +128,9 @@ public class HTTPEndPointTransformer extends AbstractEndpointTransformer {
             throw new TransformerException(e);
         }
         if (httpEndPoint.getURITemplate() != null) {
-            UriTemplate template = UriTemplate.fromTemplate(httpEndPoint.getURITemplate());
+            String uriTemplate = httpEndPoint.getURITemplate();
+            uriTemplate = uriTemplate.replaceAll("&amp;", "&");
+            UriTemplate template = UriTemplate.fromTemplate(uriTemplate);
             synapseHttpEP.setUriTemplate(template);
         }
 


### PR DESCRIPTION
## Purpose
Fix double encoding a URL in HTTP Endpoint when an already encoded URL is given.

Fix https://github.com/wso2/integration-studio/issues/265