### PR TITLE
Fix Unit Test protocol selection dialog update issue [8.0.0]

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.esb.synapse.unit.test/src/org/wso2/integrationstudio/esb/synapse/unit/test/wizard/testcase/TestCaseDetailPage.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.esb.synapse.unit.test/src/org/wso2/integrationstudio/esb/synapse/unit/test/wizard/testcase/TestCaseDetailPage.java
@@ -676,6 +676,9 @@ public class TestCaseDetailPage extends WizardPage {
         setTestCaseName(selectedTestCase.getTestCaseName());
         setResourcePath(selectedTestCase.getRequestPath());
         setResourceMethod(selectedTestCase.getRequestMethod());
+        if(selectedTestCase.getProtocolType() != null) {
+            setProtocolType(selectedTestCase.getProtocolType());
+        }
         setInputPayload(selectedTestCase.getInputPayload());
     }
 


### PR DESCRIPTION
## Purpose
Fixing the Unit Test protocol selection updates each time the dialog box opened issue.

Related issue: https://github.com/wso2/integration-studio/issues/907

