### PR TITLE
Removed HTTP4E feature from product.

### DIFF
--- a/distribution/rcp-product/org.wso2.integrationstudio.rcp.product/integrationstudio.product
+++ b/distribution/rcp-product/org.wso2.integrationstudio.rcp.product/integrationstudio.product
@@ -330,7 +330,6 @@ Please visit : http://wso2.com/products/integration-studio/
       <feature id="org.eclipse.jst.web_userdoc.feature"/>
       <feature id="org.eclipse.pde"/>
       <feature id="org.eclipse.jdt"/>
-      <feature id="org.roussev.http4e.feature" version="5.0.12"/>
       <feature id="de.jcup.yamleditor"/>
       <!-- Integration Studio kernel/platform features -->
       <feature id="org.wso2.integrationstudio.platform.feature" installMode="root"/>


### PR DESCRIPTION
## Purpose
> HTTP4e plugin causes Integration Studio Crashing #956. The purpose is to remove the feature from the IntegrationStudio and update the documentation to guide the customer to use Postman

## Related PRs
> Documentation changes: https://github.com/wso2/docs-apim/pull/5192

## Test environment
> Linux, Mac
 