### PR TITLE
[Fix] Persist the isMendatory value in TemplateMediator

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.diagram/src/org/wso2/integrationstudio/gmf/esb/diagram/custom/deserializer/SequenceTemplateDeserializer.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.diagram/src/org/wso2/integrationstudio/gmf/esb/diagram/custom/deserializer/SequenceTemplateDeserializer.java
@@ -72,7 +72,7 @@ public class SequenceTemplateDeserializer extends AbstractEsbNodeDeserializer<Te
                 TemplateParameter templateParameter = EsbFactory.eINSTANCE.createTemplateParameter();
                 templateParameter.setName(parameter.getName());
                 templateParameter.setDefaultValue((String)parameter.getDefaultValue());
-                templateParameter.setIsMandatory(templateParameter.isIsMandatory());
+                templateParameter.setIsMandatory(parameter.isMandatory());
                 executeAddValueCommand(templateModel.getParameters(), templateParameter, false);
             }
         }


### PR DESCRIPTION
## Purpose
In TemplateMediator when we change the view from source -> design -> source the "isMendatory" value is restored to false.

## Approach
Found a bug in the source code which overwrites the value of "isMendatory" with an empty template's value. Fixed that bug.