### PR TITLE
[Fix] Reverted wrong imports.

### DIFF
--- a/components/studio-platform/plugins/org.wso2.integrationstudio.dashboard/src/org/wso2/integrationstudio/dashboard/handlers/PlatformEarlyStartUpHandler.java
+++ b/components/studio-platform/plugins/org.wso2.integrationstudio.dashboard/src/org/wso2/integrationstudio/dashboard/handlers/PlatformEarlyStartUpHandler.java
@@ -25,10 +25,10 @@ import org.wso2.integrationstudio.carbonserver42.register.product.servers.Dynami
 import org.wso2.integrationstudio.carbonserver44.register.product.servers.DynamicServer44ExtensionGenerator;
 import org.wso2.integrationstudio.carbonserver44ei.register.product.servers.DynamicServer44eiExtensionGenerator;
 import org.wso2.integrationstudio.carbonserver44microei.register.product.servers.DynamicServer44MicroeiExtensionGenerator;
-import org.wso2.integrationstudio.carbonserver44microei.register.product.servers.MicroIntegratorInstance;
-import org.wso2.integrationstudio.carbonserver44microei12.register.product.servers.DynamicServer44Microei12ExtensionGenerator;
-import org.wso2.integrationstudio.carbonserver44microei40.register.product.servers.DynamicServer44Microei40ExtensionGenerator;
+import org.wso2.integrationstudio.carbonserver44microei41.register.product.servers.MicroIntegratorInstance;
 import org.wso2.integrationstudio.carbonserver44microei41.register.product.servers.DynamicServer44Microei41ExtensionGenerator;
+import org.wso2.integrationstudio.carbonserver44microei40.register.product.servers.DynamicServer44Microei40ExtensionGenerator;
+import org.wso2.integrationstudio.carbonserver44microei12.register.product.servers.DynamicServer44Microei12ExtensionGenerator;
 import org.wso2.integrationstudio.carbonserver44microei11.register.product.servers.DynamicServer44Microei11ExtensionGenerator;
 
 


### PR DESCRIPTION
## Purpose
> When migrating to JDK 11, some wrong imports were added. In this commit, those changes are reverted.
