### PR TITLE
Add class name in custom inbound endpoint

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.artifact.inboundendpoint/src/org/wso2/integrationstudio/artifact/inboundendpoint/ui/wizard/InboundEndpointProjectCreationWizard.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.artifact.inboundendpoint/src/org/wso2/integrationstudio/artifact/inboundendpoint/ui/wizard/InboundEndpointProjectCreationWizard.java
@@ -237,7 +237,7 @@ public class InboundEndpointProjectCreationWizard extends AbstractWSO2ProjectCre
 			inboundEndpoint.setName(ieModel.getName());
 			
 			if(ieModel.getProtocol().equals(CUSTOM)){
-				inboundEndpoint.setClassImpl("org.wso2.sample.inbound.CustomClass");
+				inboundEndpoint.setClassImpl("org.wso2.carbon.inbound.kafka.KafkaMessageConsumer");
 			} else {
 				inboundEndpoint.setProtocol(ieModel.getProtocol());
 				if(ieModel.getProtocol().equals(KAFKA)){


### PR DESCRIPTION
## Purpose
> As per the [doc](https://apim.docs.wso2.com/en/latest/reference/connectors/kafka-connector/kafka-inbound-endpoint-example/#kafka-inbound-endpoint-example) default class name for custom inbound endpoint is : org.wso2.carbon.inbound.kafka.KafkaMessageConsumer. Need to change the default value according to the document.


## Approach
> Updated the code to use  "org.wso2.carbon.inbound.kafka.KafkaMessageConsumer" as default value for custom inbound endpoint class name. 