### PR TITLE
[Fix] Integration Studio crashes on server config screen

### DIFF
--- a/components/studio-platform/plugins/org.wso2.integrationstudio.carbon.server.model/src/org/wso2/integrationstudio/carbon/server/model/configuration/ConfigurationOtherCommonEditorSection.java
+++ b/components/studio-platform/plugins/org.wso2.integrationstudio.carbon.server.model/src/org/wso2/integrationstudio/carbon/server/model/configuration/ConfigurationOtherCommonEditorSection.java
@@ -125,15 +125,7 @@ public abstract class ConfigurationOtherCommonEditorSection extends ServerEditor
 			public void run() {
 				while (true) {
 					Boolean serverConfigMapValue = CarbonServerCommonUtils.isServerStartBrowserPopup(server.getOriginal());
-					if (serverConfigMapValue == null) {
-						try {
-							Thread.sleep(2000);
-						} catch (InterruptedException e) {
-							log.error(e);
-						}
-						continue;
-					}
-					boolean startWSASBrowser = serverConfigMapValue;
+					boolean startWSASBrowser = serverConfigMapValue == null ? false : serverConfigMapValue;
 					boolean enableAxis2Hotupdate = CarbonServerCommonUtils.isServerHotUpdate(server.getOriginal());
 					boolean enableOSGIConsole = CarbonServerCommonUtils.isServerStartWithOSGiConsole(server.getOriginal());
 					if (startWSASCheck != null) {


### PR DESCRIPTION
## Purpose
> Fix issue: Integration studio freezes when opening server configuration screen. 

## Approach
> In the ConfigurationOtherCommonEditorSection class, there is a never-ending while loop running when going to the config overview UI. Fixed this problem. 

[1](https://github.com/wso2/integration-studio/issues/969)