### PR TITLE
[Fix] Unable to save data service

### DIFF
--- a/components/dss-tools/plugins/org.wso2.integrationstudio.ds.editor/DSSEditor/assets/js/data-handler.js
+++ b/components/dss-tools/plugins/org.wso2.integrationstudio.ds.editor/DSSEditor/assets/js/data-handler.js
@@ -1,3 +1,4 @@
+jQuery.support.cors = true;
 $(document).ready(function ($) {
 
     var portValue = resolveGetParam("port");
@@ -32,12 +33,12 @@ $(document).ready(function ($) {
 //    });
 
 
-
     $.ajax({
                 url: url,
                 type: 'GET',
                 dataType: 'text',
                 cache: false,
+                contentType: "text/plain",
                 success: function (result) {
                    var parser = new DOMParser();
                    root = parser.parseFromString(result, "text/xml");


### PR DESCRIPTION
## Purpose
> to fix [issue 1](https://github.com/wso2/integration-studio/issues/1008) [issue 2](https://github.com/wso2/integration-studio/issues/1009)

## Approach
> Reason for this issue is Jquery update. With newer versions of Jquery to use ajax with CORS support, we need to add "jQuery.support.cors = true;" explicitly. Reference : [Stackoverflow thread](https://stackoverflow.com/questions/5241088/jquery-call-to-webservice-returns-no-transport-error)
