### PR TITLE
[FIX] Property Scope doesn't change to axis2 when selecting Property Name as REST_URL_POSTFIX

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb/src/org/wso2/integrationstudio/gmf/esb/impl/PropertyMediatorImpl.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb/src/org/wso2/integrationstudio/gmf/esb/impl/PropertyMediatorImpl.java
@@ -1153,7 +1153,7 @@ public class PropertyMediatorImpl extends MediatorImpl implements PropertyMediat
         propertyNameScopeMap.put("PRESERVE_WS_ADDRESSING", PropertyScope.SYNAPSE);
         propertyNameScopeMap.put("REQUEST_HOST_HEADER", PropertyScope.SYNAPSE);
         propertyNameScopeMap.put("RESPONSE", PropertyScope.SYNAPSE);
-        propertyNameScopeMap.put("REST_URL_POSTFIX", PropertyScope.SYNAPSE);
+        propertyNameScopeMap.put("REST_URL_POSTFIX", PropertyScope.AXIS2);
         propertyNameScopeMap.put("RelatesTo", PropertyScope.SYNAPSE);
         propertyNameScopeMap.put("ReplyTo", PropertyScope.SYNAPSE);
         propertyNameScopeMap.put("SERVER_IP", PropertyScope.SYNAPSE);


### PR DESCRIPTION
## Purpose
> Fixes : [Issue 978](https://github.com/wso2/integration-studio/issues/978)
## Approach
> Changed the mapped value to AXIS2