### PR TITLE
Auto add params when selecting template.

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.edit/src-gen/org/wso2/integrationstudio/gmf/esb/presentation/EEFPropertyViewUtil.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.edit/src-gen/org/wso2/integrationstudio/gmf/esb/presentation/EEFPropertyViewUtil.java
@@ -18,6 +18,7 @@
 package org.wso2.integrationstudio.gmf.esb.presentation;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -30,6 +31,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
+import java.util.Scanner;
 
 import org.codehaus.jettison.json.JSONException;
 
@@ -358,6 +360,41 @@ public class EEFPropertyViewUtil {
         }
         return definedTemplates;
     }
+    
+	public static File getFileContent(String fileName) throws FileNotFoundException {
+		File projectPath = null;
+		IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
+		File artifact = null;
+		for (IProject activeProject : projects) {
+			if (activeProject != null) {
+				try {
+					if (activeProject.hasNature("org.wso2.developerstudio.eclipse.esb.project.nature")) {
+						ESBProjectArtifact esbProjectArtifact = new ESBProjectArtifact();
+						projectPath = activeProject.getLocation().toFile();
+						try {
+							esbProjectArtifact.fromFile(activeProject.getFile("artifact.xml").getLocation().toFile());
+							List<ESBArtifact> allESBArtifacts = esbProjectArtifact.getAllESBArtifacts();
+							for (ESBArtifact esbArtifact : allESBArtifacts) {
+								if (TYPE_TEMPLATE_SEQ.equals(esbArtifact.getType())) {
+									artifact = new File(projectPath, esbArtifact.getFile());
+								} else if (TYPE_TEMPLATE_EPT.equals(esbArtifact.getType())) {
+									artifact = new File(projectPath, esbArtifact.getFile());
+								}
+								if (artifact != null && artifact.getName().equals(fileName)) {
+									return artifact;
+								}
+							}
+						} catch (Exception e) {
+							log.error("Error occured while scanning the project for artifacts", e);
+						}
+					}
+				} catch (CoreException e) {
+					log.error("Error occured while scanning the project", e);
+				}
+			}
+		}
+		throw new FileNotFoundException();
+	}
 
     public static String spaceFormat(String str) {
         int maxLength = 120;

--- a/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb/src/org/wso2/integrationstudio/gmf/esb/impl/CallTemplateParameterImpl.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb/src/org/wso2/integrationstudio/gmf/esb/impl/CallTemplateParameterImpl.java
@@ -111,7 +111,7 @@ public class CallTemplateParameterImpl extends EsbNodeImpl implements CallTempla
      * <!-- end-user-doc -->
      * @generated
      */
-    protected CallTemplateParameterImpl() {
+    public CallTemplateParameterImpl() {
         super();
     }
 

--- a/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb/src/org/wso2/integrationstudio/gmf/esb/impl/NamespacedPropertyImpl.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb/src/org/wso2/integrationstudio/gmf/esb/impl/NamespacedPropertyImpl.java
@@ -175,7 +175,7 @@ public class NamespacedPropertyImpl extends EsbNodeImpl implements NamespacedPro
      * 
      * @generated NOT
      */
-    protected NamespacedPropertyImpl() {
+    public NamespacedPropertyImpl() {
         super();
         setNamespaces(new HashMap<String, String>());
     }


### PR DESCRIPTION
## Purpose
> Automatically add parameters to the CasllTemplateMediator param section, when the user selects the template.

## Approach
> Behavior of the change: Let's say we have two Sequence mediators created as follows,
1. Name of mediator A,  Parameters : (A-param1, A-param-2)
2. Name of mediator B,  Parameters : (B-param1, B-param-2)
3. Name od mediator C,  Parameters : (A-param1, B-param1)

Now User creates a CallMediator 
* User will have an empty parameter list in the property section.
* User select template: A in the available templates section of the CallTemplateMediator property section.
* Parameters : (A-param1, A-param-2) will be automatically added to the param table. 
* User select template: B in the available templates section of the CallTemplateMediator property section.
* Parameters : (B-param1, B-param-2) will be automatically added to the param table. Finally, the table will contain  (A-param1, A-param-2, B-param1, B-param-2)
* User select template: C in the available templates section of the CallTemplateMediator property section.
* No changes to the param table as the table already contains parameters with names equal to Mediator C's params.


Fixes : https://github.com/wso2/integration-studio/issues/999