### PR TITLE
[FIX] Supportive artifacts are not being marked

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.esb.synapse.unit.test/src/org/wso2/integrationstudio/esb/synapse/unit/test/component/DependencyTree.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.esb.synapse.unit.test/src/org/wso2/integrationstudio/esb/synapse/unit/test/component/DependencyTree.java
@@ -694,21 +694,21 @@ public class DependencyTree {
                 }
             }
         }
-		List<String> modifiedDepList = new ArrayList<>();
-		for (String element : dependencyList) {
-			modifiedDepList.add(element.replaceAll("\\\\", "").replaceAll("\\/", ""));
-		}
-		for (final TreeItem parentItem : trDependencies.getItems()) {
-			if (parentItem != null) {
-				for (final TreeItem item : parentItem.getItems()) {
-					String itemPath = item.getText(1).replaceAll("\\\\", "").replaceAll("\\/", "");
+        List<String> modifiedDepList = new ArrayList<>();
+        for (String element : dependencyList) {
+            modifiedDepList.add(element.replaceAll("\\\\", "").replaceAll("\\/", ""));
+        }
+        for (final TreeItem parentItem : trDependencies.getItems()) {
+            if (parentItem != null) {
+                for (final TreeItem item : parentItem.getItems()) {
+                    String itemPath = item.getText(1).replaceAll("\\\\", "").replaceAll("\\/", "");
 
-					if (modifiedDepList.stream().anyMatch(str -> str.trim().equals(itemPath))) {
-						item.setChecked(true);
-					}
-				}
-			}
-		}
+                    if (modifiedDepList.stream().anyMatch(str -> str.trim().equals(itemPath))) {
+                        item.setChecked(true);
+                    }
+                }
+            }
+        }
     }
 
     /**

--- a/components/esb-tools/plugins/org.wso2.integrationstudio.esb.synapse.unit.test/src/org/wso2/integrationstudio/esb/synapse/unit/test/component/DependencyTree.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.esb.synapse.unit.test/src/org/wso2/integrationstudio/esb/synapse/unit/test/component/DependencyTree.java
@@ -694,21 +694,21 @@ public class DependencyTree {
                 }
             }
         }
-        List<String> modifiedDepList = new ArrayList<>();
-        for (String element : dependencyList) {
+		List<String> modifiedDepList = new ArrayList<>();
+		for (String element : dependencyList) {
 			modifiedDepList.add(element.replaceAll("\\\\", "").replaceAll("\\/", ""));
 		}
-        for (final TreeItem parentItem : trDependencies.getItems()) {
-            if (parentItem != null) {
-                for (final TreeItem item : parentItem.getItems()) {
-                    String itemPath = item.getText(1).replaceAll("\\\\", "").replaceAll("\\/", "");
+		for (final TreeItem parentItem : trDependencies.getItems()) {
+			if (parentItem != null) {
+				for (final TreeItem item : parentItem.getItems()) {
+					String itemPath = item.getText(1).replaceAll("\\\\", "").replaceAll("\\/", "");
 
-                    if (modifiedDepList.stream().anyMatch(str -> str.trim().equals(itemPath))) {
-                        item.setChecked(true);
-                    }
-                }
-            }
-        }
+					if (modifiedDepList.stream().anyMatch(str -> str.trim().equals(itemPath))) {
+						item.setChecked(true);
+					}
+				}
+			}
+		}
     }
 
     /**

--- a/components/esb-tools/plugins/org.wso2.integrationstudio.esb.synapse.unit.test/src/org/wso2/integrationstudio/esb/synapse/unit/test/component/DependencyTree.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.esb.synapse.unit.test/src/org/wso2/integrationstudio/esb/synapse/unit/test/component/DependencyTree.java
@@ -19,6 +19,7 @@ package org.wso2.integrationstudio.esb.synapse.unit.test.component;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -693,13 +694,16 @@ public class DependencyTree {
                 }
             }
         }
-
+        List<String> modifiedDepList = new ArrayList<>();
+        for (String element : dependencyList) {
+			modifiedDepList.add(element.replaceAll("\\\\", "").replaceAll("\\/", ""));
+		}
         for (final TreeItem parentItem : trDependencies.getItems()) {
             if (parentItem != null) {
                 for (final TreeItem item : parentItem.getItems()) {
-                    String itemPath = item.getText(1);
+                    String itemPath = item.getText(1).replaceAll("\\\\", "").replaceAll("\\/", "");
 
-                    if (dependencyList.stream().anyMatch(str -> str.trim().equals(itemPath))) {
+                    if (modifiedDepList.stream().anyMatch(str -> str.trim().equals(itemPath))) {
                         item.setChecked(true);
                     }
                 }


### PR DESCRIPTION
## Purpose
> Fixes : https://github.com/wso2/integration-studio/issues/1006

## Approach
> The reason these artifacts and services are not being marked is when comparing the strings, the target string contains "/"s, and source strings contain "\"s. As a fix, removed the slashes from the string before comparing.