### PR TITLE
Class Mediator does not work out of the box

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.artifact.mediator/src/org/wso2/integrationstudio/artifact/mediator/ui/wizard/CustomMediatorCreationWizard.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.artifact.mediator/src/org/wso2/integrationstudio/artifact/mediator/ui/wizard/CustomMediatorCreationWizard.java
@@ -131,6 +131,9 @@ public class CustomMediatorCreationWizard extends AbstractWSO2ProjectCreationWiz
 			getModel().getMavenInfo().setPackageName("bundle");
 			if(!pomfile.exists()){
 				createPOM(pomfile);
+				MavenProject mavenProject = MavenUtils.getMavenProject(pomfile);
+				mavenProject.getModel().getProperties().put("CApp.type", "lib/synapse/mediator");
+				MavenUtils.saveMavenProject(mavenProject, pomfile);
 				addDependancies(project);
 			}
 			MavenProject mavenProject = MavenUtils.getMavenProject(pomfile);


### PR DESCRIPTION
## Purpose
> Fixes : https://github.com/wso2/integration-studio/issues/857

## Approach
> Root cause : When creating pom file capp.type was not added to the pom file. Fix : Changed the code to add capp.type information to the pom correctly. 