### PR TITLE
Update XSLT in datamapper only if input and output type is XML

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.visualdatamapper.diagram/src/org/wso2/integrationstudio/datamapper/diagram/part/DataMapperDiagramEditor.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.visualdatamapper.diagram/src/org/wso2/integrationstudio/datamapper/diagram/part/DataMapperDiagramEditor.java
@@ -530,7 +530,9 @@ public class DataMapperDiagramEditor extends DiagramDocumentEditor implements IG
 		//Fixing DEVTOOLESB-651
 		if (success) {
 			super.doSave(monitor);
-			updateAssociatedXsltFile(monitor);
+			if ("XML".equalsIgnoreCase(getInputSchemaType()) && "XML".equalsIgnoreCase(getOutputSchemaType())) {
+			    updateAssociatedXsltFile(monitor);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2/api-manager/issues/594

Previously regardless of the Input and Output type, the XSLT sheet was updated in the data mapper, Ideally we should only use XSLT for XML to XML mapping.