### PR TITLE
Fix shortcut issue in form view

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.diagram/src/org/wso2/integrationstudio/gmf/esb/diagram/part/EsbDiagramActionBarContributor.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.diagram/src/org/wso2/integrationstudio/gmf/esb/diagram/part/EsbDiagramActionBarContributor.java
@@ -100,8 +100,10 @@ public class EsbDiagramActionBarContributor extends MultiPageEditorActionBarCont
 						getTextAction(editor, ITextEditorActionConstants.PASTE));
 				actionBars.setGlobalActionHandler(ActionFactory.DELETE.getId(),
 						getTextAction(editor, ITextEditorActionConstants.DELETE));
-				actionBars.updateActionBars();
+			} else {
+			    actionBars.clearGlobalActionHandlers();
 			}
+			actionBars.updateActionBars();
 		}
 	}
 


### PR DESCRIPTION
## Purpose
The action handlers were overridden to support shortcut keys in the source view. As a result, the Form view will use these overridden action handlers when a source view is opened in the background. To fix this we need to clear the action handlers when the active page is changed to Design or Form view.

Fixes https://github.com/wso2/api-manager/issues/645