### PR TITLE
Make authmode optional and set the default value to 'header'

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.diagram/src/org/wso2/integrationstudio/gmf/esb/diagram/custom/deserializer/HTTPEndpointDeserializer.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.diagram/src/org/wso2/integrationstudio/gmf/esb/diagram/custom/deserializer/HTTPEndpointDeserializer.java
@@ -227,7 +227,7 @@ public class HTTPEndpointDeserializer extends AbstractEndpointDeserializer {
                 AuthorizationCodeHandler handler = (AuthorizationCodeHandler) oauthEP.getOauthHandler();
                 httpEndpointPage.httpEP_AuthType.select(2);
                 httpEndpointPage.httpEP_OAuthType.select(0);
-                httpEndpointPage.httpEP_OAuthAuthenticationMode.select(HTTPEndpointOAuthAuthenticationMode.getByName(handler.getAuthMode()).getValue());
+                httpEndpointPage.httpEP_OAuthAuthenticationMode.select(HTTPEndpointOAuthAuthenticationMode.get(handler.getAuthMode()).getValue());
                 
                 httpEndpointPage.setOAuthClientId(handler.getClientId());
                 httpEndpointPage.setOAuthClientSecret(handler.getClientSecret());
@@ -238,7 +238,7 @@ public class HTTPEndpointDeserializer extends AbstractEndpointDeserializer {
                 ClientCredentialsHandler handler = (ClientCredentialsHandler) oauthEP.getOauthHandler();
                 httpEndpointPage.httpEP_AuthType.select(2);
                 httpEndpointPage.httpEP_OAuthType.select(1);
-                httpEndpointPage.httpEP_OAuthAuthenticationMode.select(HTTPEndpointOAuthAuthenticationMode.getByName(handler.getAuthMode()).getValue());
+                httpEndpointPage.httpEP_OAuthAuthenticationMode.select(HTTPEndpointOAuthAuthenticationMode.get(handler.getAuthMode()).getValue());
                 
                 httpEndpointPage.setOAuthClientId(handler.getClientId());
                 httpEndpointPage.setOAuthClientSecret(handler.getClientSecret());
@@ -248,7 +248,7 @@ public class HTTPEndpointDeserializer extends AbstractEndpointDeserializer {
                 PasswordCredentialsHandler handler = (PasswordCredentialsHandler) oauthEP.getOauthHandler();
                 httpEndpointPage.httpEP_AuthType.select(2);
                 httpEndpointPage.httpEP_OAuthType.select(2);
-                httpEndpointPage.httpEP_OAuthAuthenticationMode.select(HTTPEndpointOAuthAuthenticationMode.getByName(handler.getAuthMode()).getValue());
+                httpEndpointPage.httpEP_OAuthAuthenticationMode.select(HTTPEndpointOAuthAuthenticationMode.get(handler.getAuthMode()).getValue());
                 
                 httpEndpointPage.setOAuthClientId(handler.getClientId());
                 httpEndpointPage.setOAuthClientSecret(handler.getClientSecret());
@@ -273,12 +273,10 @@ public class HTTPEndpointDeserializer extends AbstractEndpointDeserializer {
     }
     
     private HTTPEndpointOAuthAuthenticationMode getOAuthMode(String value) {
-        if (value.equals("header")) {
-            return HTTPEndpointOAuthAuthenticationMode.HEADER_OAUTH_AUTHENTICATION_MODE;
-        } else {
+        if ("payload".equalsIgnoreCase(value)) {
             return HTTPEndpointOAuthAuthenticationMode.PAYLOAD_OAUTH_AUTHENTICATION_MODE;
         }
-        
+        return HTTPEndpointOAuthAuthenticationMode.HEADER_OAUTH_AUTHENTICATION_MODE;
     }
     
     protected EList<EndPointProperty> getOAuthParametersList(Map<String, String> map) {

--- a/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb/src/org/wso2/integrationstudio/gmf/esb/HTTPEndpointOAuthAuthenticationMode.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb/src/org/wso2/integrationstudio/gmf/esb/HTTPEndpointOAuthAuthenticationMode.java
@@ -104,11 +104,11 @@ public enum HTTPEndpointOAuthAuthenticationMode implements Enumerator {
     public static HTTPEndpointOAuthAuthenticationMode get(String literal) {
         for (int i = 0; i < VALUES_ARRAY.length; ++i) {
             HTTPEndpointOAuthAuthenticationMode result = VALUES_ARRAY[i];
-            if (result.toString().equals(literal)) {
+            if (result.toString().equalsIgnoreCase(literal)) {
                 return result;
             }
         }
-        return null;
+        return HEADER_OAUTH_AUTHENTICATION_MODE;
     }
 
     /**


### PR DESCRIPTION
## Purpose
Make the `authMode` parameter optional and set the default value to 'header' in HTTP endpoints.

Fixes https://github.com/wso2/api-manager/issues/720