### PR TITLE
Add check to verify the project is open

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.edit/src-gen/org/wso2/integrationstudio/gmf/esb/parts/forms/DSSMediatorPropertiesEditionPartForm.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.edit/src-gen/org/wso2/integrationstudio/gmf/esb/parts/forms/DSSMediatorPropertiesEditionPartForm.java
@@ -1268,31 +1268,33 @@ public class DSSMediatorPropertiesEditionPartForm extends SectionPropertiesEditi
             // Fixing TOOLS-2322
             IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
             for (IProject workspaceProject : projects) {
-                try {
-                    if (workspaceProject.hasNature("org.wso2.developerstudio.eclipse.ds.project.nature")) {
-                    	DSSProjectArtifact dssProjectArtifact = new DSSProjectArtifact();
-                        projectPath = workspaceProject.getLocation().toFile();
-                        try {
-                            dssProjectArtifact
-                                    .fromFile(workspaceProject.getFile("artifact.xml").getLocation().toFile());
-                            List<DSSArtifact> allDSSArtifacts = dssProjectArtifact.getAllDSSArtifacts();
-                            for (DSSArtifact dssArtifact : allDSSArtifacts) {
-                                if (synapseArtifcatCategory.equals(dssArtifact.getType())) {
-                                    File artifact = new File(projectPath, dssArtifact.getFile());
-                                    String dbsName = artifact.getName().replaceAll("[.]dbs$", "");
-                                    availableList.add(dbsName);
-                                    dbsFileMap.put(dbsName, artifact);
+                if (workspaceProject != null) {
+                    try {
+                        if (workspaceProject.isOpen() && workspaceProject.hasNature("org.wso2.developerstudio.eclipse.ds.project.nature")) {
+                            DSSProjectArtifact dssProjectArtifact = new DSSProjectArtifact();
+                            projectPath = workspaceProject.getLocation().toFile();
+                            try {
+                                dssProjectArtifact
+                                        .fromFile(workspaceProject.getFile("artifact.xml").getLocation().toFile());
+                                List<DSSArtifact> allDSSArtifacts = dssProjectArtifact.getAllDSSArtifacts();
+                                for (DSSArtifact dssArtifact : allDSSArtifacts) {
+                                    if (synapseArtifcatCategory.equals(dssArtifact.getType())) {
+                                        File artifact = new File(projectPath, dssArtifact.getFile());
+                                        String dbsName = artifact.getName().replaceAll("[.]dbs$", "");
+                                        availableList.add(dbsName);
+                                        dbsFileMap.put(dbsName, artifact);
+                                    }
                                 }
+                            } catch (Exception e) {
+                                ErrorDialog.openError(shell, "Error occured while scanning the project for "
+                                        + synapseArtifcatCategory + " artifacts", e.getMessage(),
+                                        new Status(IStatus.ERROR, Activator.PLUGIN_ID, e.getMessage()));
                             }
-                        } catch (Exception e) {
-                            ErrorDialog.openError(shell, "Error occured while scanning the project for "
-                                    + synapseArtifcatCategory + " artifacts", e.getMessage(), 
-                                    new Status(IStatus.ERROR, Activator.PLUGIN_ID, e.getMessage()));
                         }
+                    } catch (CoreException e) {
+                        ErrorDialog.openError(shell, "Error occured while scanning the project", e.getMessage(),
+                                new Status(IStatus.ERROR, Activator.PLUGIN_ID, e.getMessage()));
                     }
-                } catch (CoreException e) {
-                    ErrorDialog.openError(shell, "Error occured while scanning the project", e.getMessage(), 
-                    		new Status(IStatus.ERROR, Activator.PLUGIN_ID, e.getMessage()));
                 }
             }
         }

--- a/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.edit/src-gen/org/wso2/integrationstudio/gmf/esb/parts/forms/StoreMediatorPropertiesEditionPartForm.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.edit/src-gen/org/wso2/integrationstudio/gmf/esb/parts/forms/StoreMediatorPropertiesEditionPartForm.java
@@ -979,7 +979,7 @@ public class StoreMediatorPropertiesEditionPartForm extends SectionPropertiesEdi
             IProject[] projects = ResourcesPlugin.getWorkspace().getRoot().getProjects();
             for (IProject workspaceProject : projects) {
                 try {
-                    if (workspaceProject.hasNature("org.wso2.developerstudio.eclipse.esb.project.nature")) {
+                    if (workspaceProject.isOpen() && workspaceProject.hasNature("org.wso2.developerstudio.eclipse.esb.project.nature")) {
                         ESBProjectArtifact esbProjectArtifact = new ESBProjectArtifact();
                         projectPath = workspaceProject.getLocation().toFile();
                         try {


### PR DESCRIPTION
## Purpose

When one integration project is closed, when we add a DSS Call meditator or a Store mediator to another opened project, it will show an error dialog. To fix this when iterating the project list, we need to have a check to verify the project is open.

Fixes : https://github.com/wso2/api-manager/issues/738 