### PR TITLE
Update metadataGroupId for proxy-service artifacts

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.artifact.proxyservice/src/org/wso2/integrationstudio/artifact/proxyservice/ui/wizard/ProxyServiceProjectCreationWizard.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.artifact.proxyservice/src/org/wso2/integrationstudio/artifact/proxyservice/ui/wizard/ProxyServiceProjectCreationWizard.java
@@ -116,7 +116,9 @@ public class ProxyServiceProjectCreationWizard extends AbstractWSO2ProjectCreati
 			updatePom();
 			esbProject.refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());
 			
-			String groupId = getMavenGroupId(pomfile) + ".proxy-service";
+			String mavenGroupId = getMavenGroupId(pomfile);
+			String groupId = mavenGroupId + ".proxy-service";
+			String metadataGroupId = mavenGroupId + ".metadata";
 			
 			//Adding the metadata about the proxy service to the metadata store.
 			esbProjectArtifact=new ESBProjectArtifact();
@@ -196,7 +198,7 @@ public class ProxyServiceProjectCreationWizard extends AbstractWSO2ProjectCreati
 				MetadataUtils.createMedataFileForProxyServices(metadataLocation,
 						proxyServiceModel.getProxyServiceName());
 				createMetadataArtifactEntry(metadataLocation, proxyServiceModel.getProxyServiceName(),
-						groupId + ".metadata");
+				        metadataGroupId);
 			}
 			esbProjectArtifact.toFile();
 			esbProject.refreshLocal(IResource.DEPTH_INFINITE, new NullProgressMonitor());


### PR DESCRIPTION
## Purpose
Append .metadata to the maven groupId instead of proxy-service groupId when creating metadata artifacts
Fixes: https://github.com/wso2/api-manager/issues/1321