### PR TITLE
Add macOS aarch64(Apple silicon) distribution for Integration Studio

### DIFF
--- a/distribution/rcp-product/org.wso2.integrationstudio.rcp.product/assembly/macosx.cocoa_aarch64.xml
+++ b/distribution/rcp-product/org.wso2.integrationstudio.rcp.product/assembly/macosx.cocoa_aarch64.xml
@@ -1,0 +1,31 @@
+<!--
+ ~ Copyright (c) 2023, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+<assembly>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>${project.basedir}/target/macAarch64Temp/</directory>
+      <outputDirectory>/</outputDirectory>
+      <fileMode>0777</fileMode>
+      <directoryMode>0777</directoryMode>
+    </fileSet>
+  </fileSets>
+</assembly>

--- a/distribution/rcp-product/org.wso2.integrationstudio.rcp.product/pom.xml
+++ b/distribution/rcp-product/org.wso2.integrationstudio.rcp.product/pom.xml
@@ -79,6 +79,11 @@
                             <ws>cocoa</ws>
                             <arch>x86_64</arch>
                         </environment>
+                        <environment>
+                            <os>macosx</os>
+                            <ws>cocoa</ws>
+                            <arch>aarch64</arch>
+                        </environment>
                     </environments>
                 </configuration>
             </plugin>
@@ -147,6 +152,18 @@
                             <outputDirectory>${project.build.directory}/jdk/jdk-macos</outputDirectory>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>download-jdk-macos-aarch64</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>https://product-dist.wso2.com/tools/developerstudio/jdk-distributions/OpenJDK11U-jdk_aarch64_mac_hotspot_11.0.18_10.tar.gz</url>
+                            <unpack>false</unpack>
+                            <outputDirectory>${project.build.directory}/jdk/jdk-macos-aarch64</outputDirectory>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -154,7 +171,7 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>prepare-embedded-linux64-version</id>
+                        <id>prepare-embedded-macos64-version</id>
                         <phase>package</phase>
                         <goals>
                             <goal>run</goal>
@@ -167,6 +184,23 @@
                                     <fileset dir="${project.basedir}/target/products/app/Eclipse.app" />
                                 </move>
                                 <delete file="${project.basedir}/target/products/WSO2-Integration-Studio-macosx.cocoa.x86_64.zip" />
+                            </tasks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>prepare-embedded-macosaarch64-version</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <tasks>
+                                <mkdir dir="${project.basedir}/target/macAarch64Temp" />
+                                <unzip src="${project.basedir}/target/products/WSO2-Integration-Studio-macosx.cocoa.aarch64.zip" dest="${project.basedir}/target/products/app-aarch64" />
+                                <move todir="${project.basedir}/target/macAarch64Temp/IntegrationStudio.app">
+                                    <fileset dir="${project.basedir}/target/products/app-aarch64/Eclipse.app" />
+                                </move>
+                                <delete file="${project.basedir}/target/products/WSO2-Integration-Studio-macosx.cocoa.aarch64.zip" />
                             </tasks>
                         </configuration>
                     </execution>
@@ -188,6 +222,20 @@
                             <finalName>WSO2-Integration-Studio-macosx.cocoa.x86_64</finalName>
                             <descriptors>
                                 <descriptor>${basedir}/assembly/macosx.cocoa_x86_64.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>prepare_mac_aarch64_dist</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>attached</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.basedir}/target/products/</outputDirectory>
+                            <finalName>WSO2-Integration-Studio-macosx.cocoa.aarch64</finalName>
+                            <descriptors>
+                                <descriptor>${basedir}/assembly/macosx.cocoa_aarch64.xml</descriptor>
                             </descriptors>
                         </configuration>
                     </execution>
@@ -231,6 +279,10 @@
                                 <fileSet>
                                     <sourceFile>${project.basedir}/target/products/WSO2-Integration-Studio-macosx.cocoa.x86_64.tar.gz</sourceFile>
                                     <destinationFile>${project.basedir}/../../target/products/WSO2-Integration-Studio-macosx-cocoa-x86_64.tar.gz</destinationFile>
+                                </fileSet>
+                                <fileSet>
+                                    <sourceFile>${project.basedir}/target/products/WSO2-Integration-Studio-macosx.cocoa.aarch64.tar.gz</sourceFile>
+                                    <destinationFile>${project.basedir}/../../target/products/WSO2-Integration-Studio-macosx.cocoa.aarch64.tar.gz</destinationFile>
                                 </fileSet>
                                 <fileSet>
                                     <sourceFile>${project.basedir}/target/products/WSO2-Integration-Studio-win32.win32.x86_64.zip</sourceFile>

--- a/distribution/rcp-product/org.wso2.integrationstudio.rcp.product/scripts/package-installer-script.sh
+++ b/distribution/rcp-product/org.wso2.integrationstudio.rcp.product/scripts/package-installer-script.sh
@@ -11,6 +11,7 @@ echo BASE_DIR: $BASE_DIR, PRODUCT_VERSION: $PRODUCT_VERSION and DASHBOARD_VERSIO
 PRODUCT_PATH_ROOT=$BASE_DIR/target/products
 PRODUCT_PATH_LINUX_64=$PRODUCT_PATH_ROOT/temp/linux-x86_64
 PRODUCT_PATH_MACOS=$PRODUCT_PATH_ROOT/temp/macos
+PRODUCT_PATH_MACOS_AARCH64=$PRODUCT_PATH_ROOT/temp/macos-aarch64
 PRODUCT_PATH_WIN_64=$PRODUCT_PATH_ROOT/temp/win-x86_64/IntegrationStudio
 
 PRODUCT_EXECUTABLE_NAME_DEFAULT=integrationstudio
@@ -18,12 +19,12 @@ PRODUCT_EXECUTABLE_NAME=IntegrationStudio
 PRODUCT_EXECUTABLE_CONFIG_FILE_NAME_DEFAULT=$PRODUCT_EXECUTABLE_NAME_DEFAULT.ini
 PRODUCT_EXECUTABLE_CONFIG_FILE_NAME=$PRODUCT_EXECUTABLE_NAME.ini
 
-
 # Temporary location of JDK distributions
 JDK_DISTRIBUTION_PATH=$BASE_DIR/target/jdk
 JDK_DEFAULT_DIRECTORY_NAME="jdk-home"
 JDK_DISTRIBUTION_FILE_PREFIX="OpenJDK"
 JDK_DIRECTORY_PREFIX="OpenJDK"
+JDK_AARCH64_DIRECTORY_PREFIX="jdk"
 JDK_HOME_LINUX="$JDK_DEFAULT_DIRECTORY_NAME/bin"
 JDK_HOME_WINDOWS="$JDK_DEFAULT_DIRECTORY_NAME/bin"
 JDK_HOME_MACOS="..\/Eclipse/$JDK_DEFAULT_DIRECTORY_NAME/Contents/Home/bin"
@@ -32,38 +33,49 @@ MACOS_ECLIPSE_CONFIG_PATH="$PRODUCT_PATH_MACOS/IntegrationStudio.app/Contents/Ec
 MACOS_ECLIPSE_PLIST_PATH="$PRODUCT_PATH_MACOS/IntegrationStudio.app/Contents"
 MACOS_ECLIPSE_EXECUTABLE_PATH="$PRODUCT_PATH_MACOS/IntegrationStudio.app/Contents/MacOS"
 MACOS_JDK_LIB_PATH="$PRODUCT_PATH_MACOS/IntegrationStudio.app/Contents/Eclipse/$JDK_DEFAULT_DIRECTORY_NAME/Contents/Home/jre/lib"
+MACOS_AARCH64_ECLIPSE_CONFIG_PATH="$PRODUCT_PATH_MACOS_AARCH64/IntegrationStudio.app/Contents/Eclipse"
+MACOS_AARCH64_ECLIPSE_PLIST_PATH="$PRODUCT_PATH_MACOS_AARCH64/IntegrationStudio.app/Contents"
+MACOS_AARCH64_ECLIPSE_EXECUTABLE_PATH="$PRODUCT_PATH_MACOS_AARCH64/IntegrationStudio.app/Contents/MacOS"
+MACOS_AARCH64_JDK_LIB_PATH="$PRODUCT_PATH_MACOS_AARCH64/IntegrationStudio.app/Contents/Eclipse/$JDK_DEFAULT_DIRECTORY_NAME/Contents/Home/jre/lib"
 
 JDK_DISTRIBUTION_PATH_LINUX=$JDK_DISTRIBUTION_PATH/jdk-linux
 JDK_DISTRIBUTION_PATH_WINDOWS=$JDK_DISTRIBUTION_PATH/jdk-windows
 JDK_DISTRIBUTION_PATH_MACOS=$JDK_DISTRIBUTION_PATH/jdk-macos
+JDK_DISTRIBUTION_PATH_MACOS_AARCH64=$JDK_DISTRIBUTION_PATH/jdk-macos-aarch64
 
 # Create temp directory and unzip created packages
 mkdir -p $PRODUCT_PATH_LINUX_64
 mkdir -p $PRODUCT_PATH_MACOS
+mkdir -p $PRODUCT_PATH_MACOS_AARCH64
 mkdir -p $PRODUCT_PATH_WIN_64
 
 unzip $PRODUCT_PATH_ROOT/WSO2-Integration-Studio-linux.gtk.x86_64.zip -d $PRODUCT_PATH_LINUX_64
 unzip $PRODUCT_PATH_ROOT/WSO2-Integration-Studio-macosx.cocoa.x86_64.zip -d $PRODUCT_PATH_MACOS
+unzip $PRODUCT_PATH_ROOT/WSO2-Integration-Studio-macosx.cocoa.aarch64.zip -d $PRODUCT_PATH_MACOS_AARCH64
 unzip $PRODUCT_PATH_ROOT/WSO2-Integration-Studio-win32.win32.x86_64.zip -d $PRODUCT_PATH_WIN_64
 
 # Unzip mi-dashboard to relevant packages
 unzip $PRODUCT_PATH_ROOT/wso2mi-dashboard-${DASHBOARD_VERSION}.zip -d $PRODUCT_PATH_LINUX_64/
 unzip $PRODUCT_PATH_ROOT/wso2mi-dashboard-${DASHBOARD_VERSION}.zip -d $PRODUCT_PATH_MACOS/IntegrationStudio.app/Contents/Eclipse/
+unzip $PRODUCT_PATH_ROOT/wso2mi-dashboard-${DASHBOARD_VERSION}.zip -d $PRODUCT_PATH_MACOS_AARCH64/IntegrationStudio.app/Contents/Eclipse/
 unzip $PRODUCT_PATH_ROOT/wso2mi-dashboard-${DASHBOARD_VERSION}.zip -d $PRODUCT_PATH_WIN_64/
 
 # Rename as "mi-dashboard" (this is the static name used in EI Tooling code)
 mv $PRODUCT_PATH_LINUX_64/wso2mi-dashboard-$DASHBOARD_VERSION $PRODUCT_PATH_LINUX_64/mi-dashboard
 mv $PRODUCT_PATH_MACOS/IntegrationStudio.app/Contents/Eclipse/wso2mi-dashboard-$DASHBOARD_VERSION $PRODUCT_PATH_MACOS/IntegrationStudio.app/Contents/Eclipse/mi-dashboard
+mv $PRODUCT_PATH_MACOS_AARCH64/IntegrationStudio.app/Contents/Eclipse/wso2mi-dashboard-$DASHBOARD_VERSION $PRODUCT_PATH_MACOS_AARCH64/IntegrationStudio.app/Contents/Eclipse/mi-dashboard
 mv $PRODUCT_PATH_WIN_64/wso2mi-dashboard-$DASHBOARD_VERSION $PRODUCT_PATH_WIN_64/mi-dashboard
 
 # Unzip apche maven to relevant packages
 unzip $PRODUCT_PATH_ROOT/apache-maven-${APACHE_MAVEN_VERSION}-bin.zip -d $PRODUCT_PATH_LINUX_64/
 unzip $PRODUCT_PATH_ROOT/apache-maven-${APACHE_MAVEN_VERSION}-bin.zip -d $PRODUCT_PATH_MACOS/IntegrationStudio.app/Contents/Eclipse/
+unzip $PRODUCT_PATH_ROOT/apache-maven-${APACHE_MAVEN_VERSION}-bin.zip -d $PRODUCT_PATH_MACOS_AARCH64/IntegrationStudio.app/Contents/Eclipse/
 unzip $PRODUCT_PATH_ROOT/apache-maven-${APACHE_MAVEN_VERSION}-bin.zip -d $PRODUCT_PATH_WIN_64/
 
 # Rename as "apche-maven" (this is the static name used in EI Tooling code)
 mv $PRODUCT_PATH_LINUX_64/apache-maven-$APACHE_MAVEN_VERSION $PRODUCT_PATH_LINUX_64/apache-maven
 mv $PRODUCT_PATH_MACOS/IntegrationStudio.app/Contents/Eclipse/apache-maven-${APACHE_MAVEN_VERSION} $PRODUCT_PATH_MACOS/IntegrationStudio.app/Contents/Eclipse/apache-maven
+mv $PRODUCT_PATH_MACOS_AARCH64/IntegrationStudio.app/Contents/Eclipse/apache-maven-${APACHE_MAVEN_VERSION} $PRODUCT_PATH_MACOS_AARCH64/IntegrationStudio.app/Contents/Eclipse/apache-maven
 mv $PRODUCT_PATH_WIN_64/apache-maven-${APACHE_MAVEN_VERSION} $PRODUCT_PATH_WIN_64/apache-maven
 
 # Clean up existing packages
@@ -87,6 +99,11 @@ mv $JDK_DISTRIBUTION_FILE_PREFIX* $JDK_DISTRIBUTION_NAME.tar.gz
 tar xzf $JDK_DISTRIBUTION_NAME.tar.gz -C $PRODUCT_PATH_MACOS/IntegrationStudio.app/Contents/Eclipse
 popd
 
+pushd ${JDK_DISTRIBUTION_PATH_MACOS_AARCH64}
+mv $JDK_DISTRIBUTION_FILE_PREFIX* $JDK_DISTRIBUTION_NAME.tar.gz
+tar xzf $JDK_DISTRIBUTION_NAME.tar.gz -C $PRODUCT_PATH_MACOS_AARCH64/IntegrationStudio.app/Contents/Eclipse
+popd
+
 # Configure JDKs
 pushd ${PRODUCT_PATH_LINUX_64}
 mv $JDK_DIRECTORY_PREFIX* $JDK_DEFAULT_DIRECTORY_NAME
@@ -104,6 +121,14 @@ popd
 
 pushd ${MACOS_ECLIPSE_CONFIG_PATH}
 mv $JDK_DIRECTORY_PREFIX* $JDK_DEFAULT_DIRECTORY_NAME
+sed -e '/-vmargs/i\'$'\n''-vm' integrationstudio.ini > integrationstudio_temp.ini
+sed -e '/-vmargs/i\'$'\n'$JDK_HOME_MACOS integrationstudio_temp.ini > integrationstudio.ini
+rm -f integrationstudio_temp.ini
+
+popd
+
+pushd ${MACOS_AARCH64_ECLIPSE_CONFIG_PATH}
+mv $JDK_AARCH64_DIRECTORY_PREFIX* $JDK_DEFAULT_DIRECTORY_NAME
 sed -e '/-vmargs/i\'$'\n''-vm' integrationstudio.ini > integrationstudio_temp.ini
 sed -e '/-vmargs/i\'$'\n'$JDK_HOME_MACOS integrationstudio_temp.ini > integrationstudio.ini
 rm -f integrationstudio_temp.ini
@@ -127,6 +152,14 @@ pushd ${MACOS_ECLIPSE_CONFIG_PATH}
 mv $PRODUCT_EXECUTABLE_CONFIG_FILE_NAME_DEFAULT $PRODUCT_EXECUTABLE_CONFIG_FILE_NAME
 popd
 
+pushd ${MACOS_AARCH64_ECLIPSE_EXECUTABLE_PATH}
+mv $PRODUCT_EXECUTABLE_NAME_DEFAULT $PRODUCT_EXECUTABLE_NAME
+popd
+
+pushd ${MACOS_AARCH64_ECLIPSE_CONFIG_PATH}
+mv $PRODUCT_EXECUTABLE_CONFIG_FILE_NAME_DEFAULT $PRODUCT_EXECUTABLE_CONFIG_FILE_NAME
+popd
+
 pushd ${PRODUCT_PATH_WIN_64}
 mv $PRODUCT_EXECUTABLE_NAME_DEFAULT.exe $PRODUCT_EXECUTABLE_NAME.exe
 mv $PRODUCT_EXECUTABLE_CONFIG_FILE_NAME_DEFAULT $PRODUCT_EXECUTABLE_CONFIG_FILE_NAME
@@ -135,6 +168,12 @@ popd
 #Rename Info.plist for Mac issue 
 #TODO: Need to fix this on RCP level
 pushd ${MACOS_ECLIPSE_PLIST_PATH}
+sed -e 's/integrationstudio/IntegrationStudio/; s/Integrationstudio/IntegrationStudio/; s/WSO2-Integration-Studio/WSO2-Integration-Studio/' Info.plist > Info_temp.plist
+rm Info.plist
+mv Info_temp.plist Info.plist
+popd
+
+pushd ${MACOS_AARCH64_ECLIPSE_PLIST_PATH}
 sed -e 's/integrationstudio/IntegrationStudio/; s/Integrationstudio/IntegrationStudio/; s/WSO2-Integration-Studio/WSO2-Integration-Studio/' Info.plist > Info_temp.plist
 rm Info.plist
 mv Info_temp.plist Info.plist
@@ -155,6 +194,12 @@ tar -czf WSO2-Integration-Studio-macosx.cocoa.x86_64.tar.gz *
 mv WSO2-Integration-Studio-macosx.cocoa.x86_64.tar.gz $PRODUCT_PATH_ROOT/WSO2-Integration-Studio-macosx.cocoa.x86_64.tar.gz
 popd
 
+pushd ${PRODUCT_PATH_MACOS_AARCH64}
+mv IntegrationStudio.app IntegrationStudio.app
+tar -czf WSO2-Integration-Studio-macosx.cocoa.aarch64.tar.gz *
+mv WSO2-Integration-Studio-macosx.cocoa.aarch64.tar.gz $PRODUCT_PATH_ROOT/WSO2-Integration-Studio-macosx.cocoa.aarch64.tar.gz
+popd
+
 pushd ${PRODUCT_PATH_WIN_64}
 cd ../
 zip -r $PRODUCT_PATH_ROOT/WSO2-Integration-Studio-win32.win32.x86_64.zip *
@@ -171,3 +216,4 @@ rm -rf $JDK_DISTRIBUTION_PATH
 
 rm -rf $PRODUCT_PATH_ROOT/WSO2-Integration-Studio-linux.gtk.x86_64.zip
 rm -rf $PRODUCT_PATH_ROOT/WSO2-Integration-Studio-macosx.cocoa.x86_64.zip
+rm -rf $PRODUCT_PATH_ROOT/WSO2-Integration-Studio-macosx.cocoa.aarch64.zip

--- a/distribution/rcp-product/pom.xml
+++ b/distribution/rcp-product/pom.xml
@@ -178,6 +178,11 @@
                             <ws>cocoa</ws>
                             <arch>x86_64</arch>
                         </environment>
+                        <environment>
+                            <os>macosx</os>
+                            <ws>cocoa</ws>
+                            <arch>aarch64</arch>
+                        </environment>
                     </environments>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## Purpose
Add aarch64 build for Integration Studio. This will generate an Integration Studio app that runs natively on apple processors(arm based)

Related issue: https://github.com/wso2/api-manager/issues/1480