### PR TITLE
Fix issues related to Datasource and DSS views

### DIFF
--- a/components/dss-tools/plugins/org.wso2.integrationstudio.artifact.dataservice/src/org/wso2/integrationstudio/artifact/dataservice/model/DataServiceModel.java
+++ b/components/dss-tools/plugins/org.wso2.integrationstudio.artifact.dataservice/src/org/wso2/integrationstudio/artifact/dataservice/model/DataServiceModel.java
@@ -119,6 +119,7 @@ public class DataServiceModel extends ProjectDataModel {
 			} else {
 				modelPropertyValue = container;
 			}
+			setGenerateDataService(false);
 		} else if (key.equals(DataServiceArtifactConstants.WIZARD_OPTION_DATASOURCE)) {
 		    setGenerateDataService(true);
 		    modelPropertyValue = null;

--- a/components/dss-tools/plugins/org.wso2.integrationstudio.artifact.dataservice/src/org/wso2/integrationstudio/artifact/dataservice/ui/wizard/GenerateDataServicesWizardPage.java
+++ b/components/dss-tools/plugins/org.wso2.integrationstudio.artifact.dataservice/src/org/wso2/integrationstudio/artifact/dataservice/ui/wizard/GenerateDataServicesWizardPage.java
@@ -53,7 +53,6 @@ import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.events.SelectionListener;
 import org.eclipse.swt.graphics.Rectangle;
 import org.eclipse.swt.layout.FormAttachment;
 import org.eclipse.swt.layout.FormData;
@@ -97,16 +96,8 @@ public class GenerateDataServicesWizardPage extends WizardPage {
     private Map<String, Boolean> allAvailableTables = new HashMap<String, Boolean>();   
     private Map<String, Document> avalableDatasources = new HashMap<String, Document>();    
     private String selectedDatasource;    
-    private String driverClassName;
     private Map<Button, String[]> buttonMap = new HashMap<Button, String[]>();    
     private Map<String, List<Button>> buttonTableMap = new HashMap<String, List<Button>>();  
-    private String mysqlVersionArr[] = new String[] { "Select Version", "8.0.15", "5.1.47" };    
-    private String mssqlVersionArr[] = new String[] { "Select Version", "6.4.0.jre8", "7.2.0.jre8" };   
-    private String postgresSqlVersionArr[] = new String[] { "Select Version", "42.2.5" };    
-    private String derbySqlVersionArr[] = new String[] { "Select Version", "10.15.1.3" };   
-    private String hsqlSqlVersionArr[] = new String[] { "Select Version", "2.5.0" };   
-    private String db2SqlVersionArr[] = new String[] { "Select Version", "db2jcc4" };    
-    private String informixSqlVersionArr[] = new String[] { "Select Version", "4.50.1" };    
     private Text jarLocationText; 
     private String jarLocation;
     private static IIntegrationStudioLog log = Logger.getLog(Activator.PLUGIN_ID);
@@ -125,10 +116,6 @@ public class GenerateDataServicesWizardPage extends WizardPage {
         container.setLayout(new FormLayout());
         FormData data;
         Table tblDataTables;
-        Button serverRadioButton;
-        Button browseFileRadioButton;
-        Combo versionComboBox;
-        Label versionLabel;
         Label browseLabel;
         Button browseButton;
         Button fetchTablesButton;
@@ -198,67 +185,6 @@ public class GenerateDataServicesWizardPage extends WizardPage {
             selectDriverGroup.setText("Select driver to fetch tables");
             selectDriverGroup.setLayoutData(groupData);
             selectDriverGroup.setVisible(false);
-
-            serverRadioButton = new Button(selectDriverGroup, SWT.RADIO);
-            {
-                FormData layoutData = new FormData();
-                layoutData.top = new FormAttachment(selectDriverGroup, 10);
-                layoutData.left = new FormAttachment(3);
-
-                serverRadioButton.setText("Use an existing driver");
-                serverRadioButton.setSelection(true);
-                serverRadioButton.setLayoutData(layoutData);
-
-            }
-            browseFileRadioButton = new Button(selectDriverGroup, SWT.RADIO);
-            {
-
-                FormData layoutData = new FormData();
-                layoutData.top = new FormAttachment(selectDriverGroup, 10);
-                layoutData.left = new FormAttachment(50);
-                layoutData.right = new FormAttachment(95);
-                browseFileRadioButton.setSelection(false);
-                browseFileRadioButton.setText("Use a driver in your local machine");
-                browseFileRadioButton.setLayoutData(layoutData);
-            }
-
-        }
-
-        Composite serverComposite = new Composite(selectDriverGroup, SWT.NONE);
-        {
-
-            FormLayout groupLayout = new FormLayout();
-            serverComposite.setLayout(groupLayout);
-
-            FormData groupData = new FormData();
-            groupData.top = new FormAttachment(selectDriverGroup, 10);
-            groupData.left = new FormAttachment(0);
-            groupData.right = new FormAttachment(100);
-
-            serverComposite.setLayoutData(groupData);
-
-            versionLabel = new Label(serverComposite, SWT.NONE);
-            {
-                versionLabel.setText("Version");
-
-                FormData layoutData = new FormData();
-                layoutData.top = new FormAttachment(selectDriverGroup, 40);
-                layoutData.left = new FormAttachment(4);
-                layoutData.right = new FormAttachment(20);
-                versionLabel.setLayoutData(layoutData);
-            }
-
-            versionComboBox = new Combo(serverComposite, SWT.READ_ONLY);
-            {
-                versionComboBox.setItems(new String[] { "Select Version" });
-
-                FormData layoutData = new FormData();
-                layoutData.top = new FormAttachment(selectDriverGroup, 40);
-                layoutData.left = new FormAttachment(versionLabel, 10);
-                layoutData.right = new FormAttachment(99);
-                versionComboBox.setLayoutData(layoutData);
-            }
-
         }
 
         Composite browseLocalComposite = new Composite(selectDriverGroup, SWT.NONE);
@@ -311,7 +237,7 @@ public class GenerateDataServicesWizardPage extends WizardPage {
         {
 
             FormData layoutData = new FormData();
-            layoutData.top = new FormAttachment(serverComposite, 10);
+            layoutData.top = new FormAttachment(browseLocalComposite, 10);
             layoutData.right = new FormAttachment(99);
             layoutData.width = 150;
 
@@ -319,41 +245,7 @@ public class GenerateDataServicesWizardPage extends WizardPage {
             fetchTablesButton.setLayoutData(layoutData);
             fetchTablesButton.setEnabled(false);
         }
-        
-        serverRadioButton.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                Button source = (Button) e.getSource();
-                if (source.getSelection()) {
-                    serverComposite.setVisible(true);
-                    browseLocalComposite.setVisible(false);
 
-                    versionComboBox.select(0);
-                    jarLocationText.setText("");
-                    jarLocation = "";
-
-                }
-            }
-        });
-
-        browseFileRadioButton.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                Button source = (Button) e.getSource();
-                if (source.getSelection()) {
-                    browseLocalComposite.setVisible(true);
-                    serverComposite.setVisible(false);
-                    serverRadioButton.setEnabled(true);
-
-                    jarLocationText.setEnabled(true);
-                    jarLocationText.setText("");
-                    jarLocation = "";
-                    browseButton.setEnabled(true);
-                    versionComboBox.select(0);
-                }
-            }
-        });
-        
         // input type table group
         Group tableListGroup = new Group(container, SWT.NONE);
         {
@@ -562,8 +454,6 @@ public class GenerateDataServicesWizardPage extends WizardPage {
                 buttonMap = new HashMap<Button, String[]>();
                 buttonTableMap = new HashMap<String, List<Button>>();
                 allAvailableTables = new HashMap<String, Boolean>();
-                driverClassName = null;
-                serverComposite.setVisible(false);
                 tableListGroup.setVisible(false);
                 serviceModeGroup.setVisible(false);
                 fetchTablesButton.setEnabled(false);
@@ -579,29 +469,8 @@ public class GenerateDataServicesWizardPage extends WizardPage {
                 } else {
                     selectedDatasource = (String)avalableDatasources.keySet().toArray()[comboAvalableDatasources.getSelectionIndex()];
                     Document datasourceConfig = avalableDatasources.get(selectedDatasource);
-                    driverClassName = getElementValue(datasourceConfig, "driverClassName");
-                    boolean isDriverAvailable = populateExisitngDriver(driverClassName, versionComboBox);
-                    if (!isDriverAvailable) {
-                        browseFileRadioButton.setSelection(true);
-                        serverRadioButton.setSelection(false);
-                        serverRadioButton.setEnabled(false);
-                        serverComposite.setVisible(false);
-                        browseLocalComposite.setVisible(true);
-                        versionComboBox.setEnabled(false);
-                    } else {
-                        versionComboBox.setEnabled(true);
-                    }
-                    
                     dataModel.setDatasource(getElementValue(datasourceConfig, "name"));
-                                
                     selectDriverGroup.setVisible(true);
-                    serverComposite.setVisible(true);
-                    serverRadioButton.setSelection(true);
-                    serverRadioButton.setEnabled(true);
-                    browseFileRadioButton.setEnabled(true);
-                    browseFileRadioButton.setSelection(false); 
-                    serverComposite.setVisible(true);
-                    browseLocalComposite.setVisible(false);
                 }              
                 updatePageStatus();                     
             }
@@ -640,39 +509,6 @@ public class GenerateDataServicesWizardPage extends WizardPage {
                 }                 
                 updatePageStatus();
             }
-        });
-        
-        versionComboBox.addSelectionListener(new SelectionListener() {
-            @Override
-            public void widgetSelected(SelectionEvent event) {
-                jarLocationText.setText("");
-                jarLocation = "";
-                if (versionComboBox.getText() != null || !versionComboBox.getText().isEmpty()) {
-                    String jarName = getDBDriverJarName(driverClassName) + "-" +  
-                            versionComboBox.getText() + ".jar";                   
-                    String driverUrl = "";
-                    try {
-                        driverUrl = DataServicesWizardConstants.DBUrlParams.DB_DRIVER_URL_BASE + getLibDirPath() + 
-                                DataServicesWizardConstants.DBUrlParams.DB_DRIVER_JAR_BASE + jarName + 
-                                DataServicesWizardConstants.DBUrlParams.DB_URL_JDBC_SUFFIX;
-                    } catch (URISyntaxException | IOException e) {
-                        showMessageBox("Error while loading driver jar", e.getMessage(), SWT.ICON_ERROR);
-                    }
-                    jarLocationText.setText(driverUrl);
-                    jarLocation = driverUrl;
-                    fetchTablesButton.setEnabled(true);                 
-                }
-
-                if (versionComboBox.getText().equals("Select Version")) {
-                    fetchTablesButton.setEnabled(false);
-                } 
-            }
-
-            @Override
-            public void widgetDefaultSelected(SelectionEvent e) {
-                fetchTablesButton.setEnabled(false);
-            }
-
         });
 
         browseButton.addListener(SWT.Selection, new Listener() {
@@ -891,47 +727,7 @@ public class GenerateDataServicesWizardPage extends WizardPage {
         dia.open();
 
     }
-    
-    private boolean populateExisitngDriver(String driverClassName, Combo versionComboBox) {
-        boolean isAvaialble = true;
-        switch (driverClassName) {
 
-        case DataServicesWizardConstants.DBDrivers.MYSQL_DRIVER:
-            versionComboBox.setItems(mysqlVersionArr);
-            break;
-
-        case DataServicesWizardConstants.DBDrivers.MS_SQL_DRIVER:
-            versionComboBox.setItems(mssqlVersionArr);
-            break;
-
-        case DataServicesWizardConstants.DBDrivers.POSTGRESQL_DRIVER:
-            versionComboBox.setItems(postgresSqlVersionArr);
-            break;
-
-        case DataServicesWizardConstants.DBDrivers.DERBY_CLIENT_DRIVER:
-            versionComboBox.setItems(derbySqlVersionArr);
-            break;
-
-        case DataServicesWizardConstants.DBDrivers.HSQL_DRIVER:
-            versionComboBox.setItems(hsqlSqlVersionArr);
-            break;
-
-        case DataServicesWizardConstants.DBDrivers.DB2_DRIVER:
-            versionComboBox.setItems(db2SqlVersionArr);
-            break;
-
-        case DataServicesWizardConstants.DBDrivers.INFORMIX_DRIVER:
-            versionComboBox.setItems(informixSqlVersionArr);
-            break;
-
-        default:
-            isAvaialble = false;
-
-        }
-        versionComboBox.select(0);
-        return isAvaialble;
-    }
-    
     /**
      * Validate the wizard page field data and update the page when the validate is
      * failed.
@@ -1095,31 +891,7 @@ public class GenerateDataServicesWizardPage extends WizardPage {
         }
         return elementNode.getNodeValue();
     }
-    
-    private String getDBDriverJarName(String className) {
-        String jarName = "";
 
-        switch (className) {
-        case DataServicesWizardConstants.DBDrivers.MYSQL_DRIVER:
-            jarName = DataServicesWizardConstants.DBConnectionParams.MYSQL_JAR;
-            break;
-        case DataServicesWizardConstants.DBDrivers.MS_SQL_DRIVER:
-            jarName = DataServicesWizardConstants.DBConnectionParams.MSSQL_JAR;
-            break;
-        case DataServicesWizardConstants.DBDrivers.POSTGRESQL_DRIVER:
-            jarName = DataServicesWizardConstants.DBConnectionParams.POSTGRESSQL_JAR;
-            break;
-        case DataServicesWizardConstants.DBDrivers.DERBY_CLIENT_DRIVER:
-            jarName = DataServicesWizardConstants.DBConnectionParams.DERBY_JAR;
-            break;
-        case DataServicesWizardConstants.DBDrivers.H2_DRIVER:
-            jarName = DataServicesWizardConstants.DBConnectionParams.H2_JAR;
-            break;
-        }
-
-        return jarName;
-    }
-    
     public String getLibDirPath() throws URISyntaxException, IOException {
         URL libURL = DsEditorPlugin.getPlugin().getBundle().getEntry("lib");
         URL resolvedFolderURL = FileLocator.toFileURL(libURL);

--- a/components/dss-tools/plugins/org.wso2.integrationstudio.artifact.datasource/DataSourceEditor/assets/js/data-handler.js
+++ b/components/dss-tools/plugins/org.wso2.integrationstudio.artifact.datasource/DataSourceEditor/assets/js/data-handler.js
@@ -63,7 +63,7 @@ $(document).ready(function ($) {
     window.params = [];
     window.isInputMappingEdit = false;
     window.mappingToBeDeleted = EMPTY_STRING;
-
+    $.support.cors = true;
     var currentPage = retrieveDSMetadata(CURRENT_PAGE_KEY, url);
 
     if (currentPage == CURRENT_PAGE_VAL_DESIGN) {
@@ -156,8 +156,6 @@ $(document).ready(function ($) {
             populateDBEngineDefaults(dbEngineType);
         }
         dataModel.definition.rdbms_conf.default_conf.db_engine = dbEngineType;
-
-        setTestConnectionRDBMSVersion(dbEngineType);
 
         //input validation
         $("#ds-driver-class-inputgroup-error").remove();
@@ -268,6 +266,9 @@ $(document).ready(function ($) {
         var dsUseDsFactory = $("#ds-use-factory-check").is(":checked");
         dataModel.definition.rdbms_conf.jndi_conf.useDSFactory = dsUseDsFactory;
 
+        updateDataModelFromJNDIPropTable(true);
+        updateDataModelFromExtPropTable(true);
+
         xmlSource = generateXmlSource(dataModel);
         saveAll(xmlSource, url, function () { });
         var metadata = DS_METADATA_DATA_MODEL + DS_METADATA_KEYVALUE_SEPARATOR + JSON.stringify(dataModel);
@@ -281,7 +282,7 @@ $(document).ready(function ($) {
         $("#ds-ext-properties-table tbody").append(markup);
     });
 
-    function updateDataModelFromExtPropTable() {
+    function updateDataModelFromExtPropTable(updateOnly) {
         var props = [];
 
         $("#ds-ext-properties-table table tbody tr").each(function () {
@@ -297,8 +298,10 @@ $(document).ready(function ($) {
 
         dataModel.definition.rdbms_conf.ext_conf.properties = props;
 
-        var metadata = DS_METADATA_DATA_MODEL + DS_METADATA_KEYVALUE_SEPARATOR + JSON.stringify(dataModel);
-        saveDSMetadata(metadata, url, function () { });
+        if (!updateOnly) {
+            var metadata = DS_METADATA_DATA_MODEL + DS_METADATA_KEYVALUE_SEPARATOR + JSON.stringify(dataModel);
+            saveDSMetadata(metadata, url, function () { });
+        }
     }
 
     $(document).on('change', '#ds-ext-properties-table', function () {
@@ -330,7 +333,7 @@ $(document).ready(function ($) {
         $("#jndi-properties-table tbody").append(markup);
     });
 
-    function updateDataModelFromJNDIPropTable() {
+    function updateDataModelFromJNDIPropTable(updateOnly) {
         var props = [];
 
         $("#jndi-properties-table table tbody tr").each(function () {
@@ -345,8 +348,10 @@ $(document).ready(function ($) {
         });
         dataModel.definition.rdbms_conf.jndi_conf.properties = props;
 
-        var metadata = DS_METADATA_DATA_MODEL + DS_METADATA_KEYVALUE_SEPARATOR + JSON.stringify(dataModel);
-        saveDSMetadata(metadata, url, function () { });
+        if (!updateOnly) {
+            var metadata = DS_METADATA_DATA_MODEL + DS_METADATA_KEYVALUE_SEPARATOR + JSON.stringify(dataModel);
+            saveDSMetadata(metadata, url, function () { });
+        }
     }
 
     $(document).on('change', '#jndi-properties-table', function () {

--- a/components/dss-tools/plugins/org.wso2.integrationstudio.artifact.datasource/DataSourceEditor/assets/js/data-handler.js
+++ b/components/dss-tools/plugins/org.wso2.integrationstudio.artifact.datasource/DataSourceEditor/assets/js/data-handler.js
@@ -17,6 +17,7 @@
 */
 
 $(document).ready(function ($) {
+    var timeout = null;
     var portValue = resolveGetParam("port");
     var url = "http://127.0.0.1:" + portValue + "/datasourceeditor/service";
     // Data model JSON which is transfered between design and source views
@@ -108,7 +109,7 @@ $(document).ready(function ($) {
 
     /** Start of Event handlers **/
 
-    $("#ds-form").on("change", function (e) {
+    $("#ds-form").on("change keyup", function (e) {
         e.preventDefault();
 
         //input validation
@@ -269,10 +270,14 @@ $(document).ready(function ($) {
         updateDataModelFromJNDIPropTable(true);
         updateDataModelFromExtPropTable(true);
 
-        xmlSource = generateXmlSource(dataModel);
-        saveAll(xmlSource, url, function () { });
-        var metadata = DS_METADATA_DATA_MODEL + DS_METADATA_KEYVALUE_SEPARATOR + JSON.stringify(dataModel);
-        saveDSMetadata(metadata, url, function () { });
+        clearTimeout(timeout);
+
+        timeout = setTimeout(function() {
+	        xmlSource = generateXmlSource(dataModel);
+	        saveAll(xmlSource, url, function () { });
+	        var metadata = DS_METADATA_DATA_MODEL + DS_METADATA_KEYVALUE_SEPARATOR + JSON.stringify(dataModel);
+	        saveDSMetadata(metadata, url, function () { });
+        }, 500);
     });
 
     //--- Start of External Datasource - Properties table ---//

--- a/components/dss-tools/plugins/org.wso2.integrationstudio.artifact.datasource/DataSourceEditor/assets/js/datasources-util.js
+++ b/components/dss-tools/plugins/org.wso2.integrationstudio.artifact.datasource/DataSourceEditor/assets/js/datasources-util.js
@@ -24,10 +24,10 @@
  */
 function generateXmlSource(dataModel) {
     var xmlString =
-        `<datasource>
-            <name>${dataModel.name}</name>
-            <description>${dataModel.description}</description>
-        </datasource>`;
+        "<datasource>" +
+        "<name>" + dataModel.name + "</name>" +
+        "<description>" + dataModel.description + "</description>" +
+        "</datasource>";
     var parser = new DOMParser();
     var xmlSourceRoot = parser.parseFromString(xmlString, "text/xml");
 
@@ -150,28 +150,28 @@ function generateXmlSource(dataModel) {
  * @param xmlSourceRoot XML source code object
  */
 function updateDataModelFromXml(dataModel, xmlSourceRoot) {
-
     if (typeof xmlSourceRoot == "object") {
+        let serializer = new XMLSerializer();
         let dss = xmlSourceRoot.getElementsByTagName("datasource");
         if (dss.length > 0) {
 
             let ds = dss[0];
             let nameElements = ds.getElementsByTagName("name");
-            let dsName = nameElements.length > 0 ? nameElements[0].innerHTML : EMPTY_STRING;
+            let dsName = nameElements.length > 0 ? serializer.serializeToString(nameElements[0].childNodes[0]) : EMPTY_STRING;
             dataModel.name = dsName;
 
             let descriptionElements = ds.getElementsByTagName("description");
-            let dsDescription = descriptionElements.length > 0 ? descriptionElements[0].innerHTML : EMPTY_STRING;
+            let dsDescription = descriptionElements.length > 0 ? serializer.serializeToString(descriptionElements[0].childNodes[0]) : EMPTY_STRING;
             dataModel.description = dsDescription;
 
             //JNDI configs
             let jndiConfigElements = ds.getElementsByTagName("jndiConfig");
             if (jndiConfigElements.length > 0) {
                 var jndiNameElements = jndiConfigElements[0].getElementsByTagName("name");
-                var jndiName = jndiNameElements.length > 0 ? jndiNameElements[0].innerHTML : EMPTY_STRING;
+                var jndiName = jndiNameElements.length > 0 ? serializer.serializeToString(jndiNameElements[0].childNodes[0]) : EMPTY_STRING;
                 dataModel.definition.rdbms_conf.jndi_conf.name = jndiName;
-                var useDSFactory = jndiConfigElements[0].getAttribute("useDataSourceFactory") == TRUE_STRING ? true : false;
 
+                var useDSFactory = jndiConfigElements[0].getAttribute("useDataSourceFactory") == TRUE_STRING ? true : false;
                 dataModel.definition.rdbms_conf.jndi_conf.useDSFactory = useDSFactory;
 
                 var jndiEnvElements = jndiConfigElements[0].getElementsByTagName("environment");
@@ -181,7 +181,7 @@ function updateDataModelFromXml(dataModel, xmlSourceRoot) {
                     for (var i = 0; i < propertyElements.length; i++) {
                         var propElement = propertyElements[i];
                         var propName = propElement.getAttribute('name');
-                        var propValue = propElement.innerHTML;
+                        var propValue = serializer.serializeToString(propElement.childNodes[0]);
                         if (propName != EMPTY_STRING && propValue != EMPTY_STRING) {
                             var newProp = { "name": propName, "value": propValue };
                             props.push(newProp);
@@ -189,7 +189,6 @@ function updateDataModelFromXml(dataModel, xmlSourceRoot) {
                     }
                     dataModel.definition.rdbms_conf.jndi_conf.properties = props;
                 }
-
             }
 
             let definitionElements = ds.getElementsByTagName('definition');
@@ -207,7 +206,7 @@ function updateDataModelFromXml(dataModel, xmlSourceRoot) {
                         if (dataSourceClassNameElements.length > 0 && driverClassNameElements.length == 0) {
                             dataModel.definition.rdbms_conf.provider = RDBMS_TYPE_EXTERNAL;
 
-                            var dsClassName = dataSourceClassNameElements[0].innerHTML;
+                            var dsClassName = serializer.serializeToString(dataSourceClassNameElements[0].childNodes[0]);
                             dataModel.definition.rdbms_conf.ext_conf.dsClassName = dsClassName;
 
                             var dsPropsElements = configurationElements[0].getElementsByTagName('dataSourceProps');
@@ -217,7 +216,7 @@ function updateDataModelFromXml(dataModel, xmlSourceRoot) {
                                 for (var i = 0; i < propertyElements.length; i++) {
                                     var propElement = propertyElements[i];
                                     var propName = propElement.getAttribute('name');
-                                    var propValue = propElement.innerHTML;
+                                    var propValue = serializer.serializeToString(propElement.childNodes[0]);
                                     if (propName != EMPTY_STRING && propValue != EMPTY_STRING) {
                                         var newProp = { "name": propName, "value": propValue };
                                         props.push(newProp);
@@ -225,33 +224,31 @@ function updateDataModelFromXml(dataModel, xmlSourceRoot) {
                                 }
                                 dataModel.definition.rdbms_conf.ext_conf.properties = props;
                             }
-
                         } else {
                             dataModel.definition.rdbms_conf.provider = RDBMS_TYPE_DEFAULT;
 
                             if (driverClassNameElements.length > 0) {
-                                var dbEngine = getDBEngineFromDriverClass(driverClassNameElements[0].innerHTML);
+                                var driverClass = serializer.serializeToString(driverClassNameElements[0].childNodes[0]);
+                                dataModel.definition.rdbms_conf.default_conf.driverClassName = driverClass;
+
+                                var dbEngine = getDBEngineFromDriverClass(driverClass);
                                 dataModel.definition.rdbms_conf.default_conf.db_engine = dbEngine;
                             } else {
+                                dataModel.definition.rdbms_conf.default_conf.driverClassName = EMPTY_STRING;
                                 dataModel.definition.rdbms_conf.default_conf.db_engine = EMPTY_STRING;
                             }
 
-                            var driverClassNameElements = configurationElements[0].getElementsByTagName('driverClassName');
-                            var driverClass = driverClassNameElements.length > 0 ? driverClassNameElements[0].innerHTML : EMPTY_STRING;
-                            dataModel.definition.rdbms_conf.default_conf.driverClassName = driverClass;
-
                             var urlElements = configurationElements[0].getElementsByTagName('url');
-                            var url = urlElements.length > 0 ? urlElements[0].innerHTML : EMPTY_STRING;
+                            var url = urlElements.length > 0 ? serializer.serializeToString(urlElements[0].childNodes[0]) : EMPTY_STRING;
                             dataModel.definition.rdbms_conf.default_conf.url = url;
 
                             var usernameElements = configurationElements[0].getElementsByTagName('username');
-                            var username = usernameElements.length > 0 ? usernameElements[0].innerHTML : EMPTY_STRING;
+                            var username = usernameElements.length > 0 ? serializer.serializeToString(usernameElements[0].childNodes[0]) : EMPTY_STRING;
                             dataModel.definition.rdbms_conf.default_conf.username = username;
 
                             var passwordElements = configurationElements[0].getElementsByTagName('password');
-                            var password = passwordElements.length > 0 ? passwordElements[0].innerHTML : EMPTY_STRING;
+                            var password = passwordElements.length > 0 ? serializer.serializeToString(passwordElements[0].childNodes[0]) : EMPTY_STRING;
                             dataModel.definition.rdbms_conf.default_conf.password = password;
-
                         }
 
                         //Configuration parameters
@@ -261,7 +258,7 @@ function updateDataModelFromXml(dataModel, xmlSourceRoot) {
                             var tagName = allParameterTagNames[i];
                             var parameterElements = configurationElements[0].getElementsByTagName(tagName);
                             if (parameterElements.length > 0) {
-                                var value = parameterElements[0].innerHTML;
+                                var value = serializer.serializeToString(parameterElements[0].childNodes[0]);
                                 parameters.push({ "tag": tagName, "value": value });
 
                             }
@@ -272,7 +269,7 @@ function updateDataModelFromXml(dataModel, xmlSourceRoot) {
                 } else {
                     dataModel.definition.type = DS_TYPE_CUSTOM;
                     dataModel.definition.custom_conf.ds_type = dsType;
-                    var config = definitionElements[0].innerHTML;
+                    var config = serializer.serializeToString(definitionElements[0].childNodes[0]);
                     dataModel.definition.custom_conf.config = config;
                 }
             }
@@ -288,7 +285,6 @@ function updateDataModelFromXml(dataModel, xmlSourceRoot) {
  * @param dataModel JSON dataModel object with data source configuration.
  */
 function populateDesignViewFromDataModel(dataModel) {
-
     $("#ds-name-input").val(dataModel.name);
     $("#ds-desc-input").val(dataModel.description);
 
@@ -306,14 +302,11 @@ function populateDesignViewFromDataModel(dataModel) {
             var tds = tr.find('td');
             tds[0].firstChild.value = prop.name;
             tds[1].firstChild.value = prop.value;
-
         } else {
-
-            var markup = `<tr>
-                <td><input type='text' placeholder='Property Name' class='form-control' style='width: 100%;' value="${prop.name}" autocomplete='off' autocorrect='off' autocapitalize'off' spellcheck='false'/></td>
-                <td><input type='text' placeholder='Property Value' class='form-control' style='width: 100%;' value="${prop.value}" autocomplete='off' autocorrect='off' autocapitalize'off' spellcheck='false'/></td>
-                <td class='text-center'><i class='fa fa-trash'></i></td></tr>`;
-
+            var markup = "<tr>" +
+                "<td><input type='text' placeholder='Property Name' class='form-control' style='width: 100%;' value='" + prop.name + "' autocomplete='off' autocorrect='off' autocapitalize='off' spellcheck='false'/></td>" +
+                "<td><input type='text' placeholder='Property Value' class='form-control' style='width: 100%;' value='" + prop.value + "' autocomplete='off' autocorrect='off' autocapitalize='off' spellcheck='false'/></td>" +
+                "<td class='text-center'><i class='fa fa-trash'></i></td></tr>";
             $("#jndi-properties-table tbody").append(markup);
         }
     }
@@ -342,14 +335,11 @@ function populateDesignViewFromDataModel(dataModel) {
             var tds = tr.find('td');
             tds[0].firstChild.value = prop.name;
             tds[1].firstChild.value = prop.value;
-
         } else {
-
-            var markup = `<tr>
-                <td><input type='text' placeholder='Property Name' class='form-control' style='width: 100%;' value="${prop.name}" autocomplete='off' autocorrect='off' autocapitalize'off' spellcheck='false'/></td>
-                <td><input type='text' placeholder='Property Value' class='form-control' style='width: 100%;' value="${prop.value}" autocomplete='off' autocorrect='off' autocapitalize'off' spellcheck='false'/></td>
-                <td class='text-center'><i class='fa fa-trash'></i></td></tr>`;
-
+            var markup = "<tr>" +
+                "<td><input type='text' placeholder='Property Name' class='form-control' style='width: 100%;' value='" + prop.name + "' autocomplete='off' autocorrect='off' autocapitalize='off' spellcheck='false'/></td>" +
+                "<td><input type='text' placeholder='Property Value' class='form-control' style='width: 100%;' value='" + prop.value + "' autocomplete='off' autocorrect='off' autocapitalize='off' spellcheck='false'/></td>" +
+                "<td class='text-center'><i class='fa fa-trash'></i></td></tr>";
             $("#ds-ext-properties-table tbody").append(markup);
         }
     }


### PR DESCRIPTION
## Purpose
This PR contains the fixes for the following issues,

1. Fix issues in New Datasource UI in Windows
Port the fix https://github.com/wso2/integration-studio/pull/1182 to the master branch
Fixes: https://github.com/wso2/api-manager/issues/1588

2. Remove the existing JDBC driver option when fetching tables in the dataservice wizard
Since we have removed the JDBC drivers packed within the Integration Studio with #1157
we need to remove the `Use an existing driver` option when fetching tables in the dataservice wizard
Fixes: https://github.com/wso2/api-manager/issues/1587

3. Fix datasource design view not getting saved
In the current implementation, an `onChange` listener was used in the design view which gets triggered when we click the form
Therefore, add an `onKeyUp` listener with a timeout to trigger the save events for input fields
Fixes: https://github.com/wso2/api-manager/issues/1580

4. Fix Inconsistency in Data Service creation wizard
The 'Generate Data Service from Datasource' page is shown regardless of the radio button selection if we first
select the 'Generate Data Service from Datasource' radio button.
To fix this we need to reset the 'isGenerateDataService' flag when other radio buttons are clicked.
Fixes: https://github.com/wso2/api-manager/issues/1597