### PR TITLE
Add option to define runtime version for projects

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.esb.project/project_wizard_esb_solution.xml
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.esb.project/project_wizard_esb_solution.xml
@@ -12,6 +12,16 @@
 			<data modelProperty="mmm.project.name" type="string"
 				fieldController="org.wso2.integrationstudio.esb.project.controller.ESBSolutionProjectFieldController">Integration Project Name</data>
 
+			<group id="project.runtime.group" title="Runtime Version" />
+
+			<data modelProperty="project.runtime.default.version.choice" type="choice"
+				fieldController="org.wso2.integrationstudio.esb.project.controller.ESBSolutionProjectFieldController"
+				group="project.runtime.group">Use Default version</data>
+
+			<data modelProperty="project.runtime.version" type="string"
+				fieldController="org.wso2.integrationstudio.esb.project.controller.ESBSolutionProjectFieldController"
+				group="project.runtime.group">Runtime version</data>
+
 			<data modelProperty="mmm.project.choice" type="choice"
 				fieldController="org.wso2.integrationstudio.esb.project.controller.ESBSolutionProjectFieldController">Wrap child modules with the parent project</data>
 			

--- a/components/esb-tools/plugins/org.wso2.integrationstudio.esb.project/src/org/wso2/integrationstudio/esb/project/controller/ESBSolutionProjectFieldController.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.esb.project/src/org/wso2/integrationstudio/esb/project/controller/ESBSolutionProjectFieldController.java
@@ -83,6 +83,8 @@ public class ESBSolutionProjectFieldController extends ESBProjectFieldController
             updateFields.add(DATA_SERVICE_PROJECT_NAME);
         } else if (modelProperty.equals(DATA_SOURCE_PROJECT_CHECKED)) {
             updateFields.add(DATA_SOURCE_PROJECT_NAME);
+        } else if (modelProperty.equals(PROJECT_RUNTIME_DEFAULT_VERSION_CHECKED)) {
+            updateFields.add(PROJECT_RUNTIME_VERSION);
         }
         return updateFields;
     }
@@ -115,6 +117,8 @@ public class ESBSolutionProjectFieldController extends ESBProjectFieldController
             }
         } else if (modelProperty.equals(ESB_PROJECT_CHOICE) && !mmmProjectEnabled) {
             return false;
+        } else if (modelProperty.equals(PROJECT_RUNTIME_VERSION)) {
+            return !((ESBSolutionProjectModel) model).isDefaultRuntimeVersionChecked();
         }
         return super.isEnableField(modelProperty, model);
     }

--- a/components/esb-tools/plugins/org.wso2.integrationstudio.esb.project/src/org/wso2/integrationstudio/esb/project/model/ESBSolutionProjectModel.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.esb.project/src/org/wso2/integrationstudio/esb/project/model/ESBSolutionProjectModel.java
@@ -17,6 +17,8 @@ package org.wso2.integrationstudio.esb.project.model;
 
 import org.wso2.integrationstudio.esb.project.utils.SolutionProjectArtifactConstants;
 import org.wso2.integrationstudio.platform.core.exception.ObserverFailedException;
+import org.wso2.integrationstudio.platform.ui.utils.PlatformUIConstants;
+
 import static org.wso2.integrationstudio.esb.project.utils.SolutionProjectArtifactConstants.*;
 
 public class ESBSolutionProjectModel extends ESBProjectModel {
@@ -28,6 +30,8 @@ public class ESBSolutionProjectModel extends ESBProjectModel {
     private String dockerExporterProjectName;
     private String kubernetesExporterProjectName;
     private String mmmProjectName;
+    private String projectRuntimeVersion = PlatformUIConstants.EMBEDDED_RUNTIME_DEFAULT_VERSION;
+    private boolean isDefaultRuntimeVersionChecked = true;
     private String dataServiceProjectName;
     private String dataSourceProjectName;
     private boolean registryProjectChecked = false;
@@ -46,6 +50,22 @@ public class ESBSolutionProjectModel extends ESBProjectModel {
         return this.mmmProjectName;
     }
     
+    public String getProjectRuntimeVersion() {
+        return projectRuntimeVersion;
+    }
+
+    public void setProjectRuntimeVersion(String projectRuntimeVersion) {
+        this.projectRuntimeVersion = projectRuntimeVersion;
+    }
+
+    public boolean isDefaultRuntimeVersionChecked() {
+        return isDefaultRuntimeVersionChecked;
+    }
+
+    public void setDefaultRuntimeVersionChecked(boolean isDefaultRuntimeVersionChecked) {
+        this.isDefaultRuntimeVersionChecked = isDefaultRuntimeVersionChecked;
+    }
+
     public void setConfigProjectChecked(boolean isConfigProjectChecked) {
         this.isConfigProjectChecked = isConfigProjectChecked;
     }
@@ -157,6 +177,10 @@ public class ESBSolutionProjectModel extends ESBProjectModel {
                 return isDataSourceProjectChecked();
             } else if (key.equals(DATA_SOURCE_PROJECT_NAME)) {
                 return getDataSourceProjectName();
+            } else if (key.equals(PROJECT_RUNTIME_VERSION)) {
+                return getProjectRuntimeVersion();
+            } else if (key.equals(PROJECT_RUNTIME_DEFAULT_VERSION_CHECKED)) {
+                return isDefaultRuntimeVersionChecked();
             }
         }
         return modelPropertyValue;
@@ -232,6 +256,11 @@ public class ESBSolutionProjectModel extends ESBProjectModel {
             setDataServiceProjectChecked((boolean) data);
         } else if (key.equals(DATA_SOURCE_PROJECT_CHECKED)) {
             setDataSourceProjectChecked((boolean) data);
+        } else if (key.equals(PROJECT_RUNTIME_VERSION)) {
+            setProjectRuntimeVersion(value);
+        } else if (key.equals(PROJECT_RUNTIME_DEFAULT_VERSION_CHECKED)) {
+            setDefaultRuntimeVersionChecked((boolean) data);
+            setProjectRuntimeVersion(PlatformUIConstants.EMBEDDED_RUNTIME_DEFAULT_VERSION);
         }
 
         return returnResult;

--- a/components/esb-tools/plugins/org.wso2.integrationstudio.esb.project/src/org/wso2/integrationstudio/esb/project/ui/wizard/ESBSolutionProjectCreationWizard.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.esb.project/src/org/wso2/integrationstudio/esb/project/ui/wizard/ESBSolutionProjectCreationWizard.java
@@ -373,6 +373,8 @@ public class ESBSolutionProjectCreationWizard extends AbstractWSO2ProjectCreatio
             dataSourceProjectCreationWizard.performFinish();
         }
 
+        addRuntimeVersionToPOM(pomFile, esbSolutionProjectModel.getProjectRuntimeVersion());
+
         getShell().getDisplay().asyncExec(new Runnable() {
             @Override
             public void run() {
@@ -395,6 +397,17 @@ public class ESBSolutionProjectCreationWizard extends AbstractWSO2ProjectCreatio
 		esbSolutionProjectModel.getMavenInfo().setGroupId(mavenProject.getGroupId());
 		esbSolutionProjectModel.getMavenInfo().setArtifactId(name);
 		esbSolutionProjectModel.getMavenInfo().setVersion(mavenProject.getVersion());
+	}
+
+	private void addRuntimeVersionToPOM(File pomLocation, String runtimeVersion) {
+	    MavenProject mavenProject = getMavenProject(pomLocation);
+	    // TODO define a constant which can be access by the Export and Run wizard
+	    mavenProject.getProperties().put("project.runtime.version", runtimeVersion);
+	    try {
+	        MavenUtils.saveMavenProject(mavenProject, pomFile);
+	    } catch (Exception e) {
+	        log.error("Error occured while trying to save the maven project", e);
+	    }
 	}
 
 	public MavenProject getMavenProject(File pomLocation) {

--- a/components/esb-tools/plugins/org.wso2.integrationstudio.esb.project/src/org/wso2/integrationstudio/esb/project/utils/SolutionProjectArtifactConstants.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.esb.project/src/org/wso2/integrationstudio/esb/project/utils/SolutionProjectArtifactConstants.java
@@ -22,6 +22,8 @@ public final class SolutionProjectArtifactConstants extends NLS {
 	public static final String BUNDLE_NAME = "org.wso2.integrationstudio.esb.project.utils.constants";
 	
 	public static String MMM_PROJECT_NAME;
+	public static String PROJECT_RUNTIME_DEFAULT_VERSION_CHECKED;
+	public static String PROJECT_RUNTIME_VERSION;
 	public static String MMM_PROJECT_CHOICE;
 	public static String ESB_PROJECT_NAME;
 	public static String ESB_PROJECT_CHOICE;

--- a/components/esb-tools/plugins/org.wso2.integrationstudio.esb.project/src/org/wso2/integrationstudio/esb/project/utils/constants.properties
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.esb.project/src/org/wso2/integrationstudio/esb/project/utils/constants.properties
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 MMM_PROJECT_NAME=mmm.project.name
+PROJECT_RUNTIME_DEFAULT_VERSION_CHECKED=project.runtime.default.version.choice
+PROJECT_RUNTIME_VERSION=project.runtime.version
 MMM_PROJECT_CHOICE=mmm.project.choice
 ESB_PROJECT_NAME=project.name
 ESB_PROJECT_CHOICE=solution.config.choice

--- a/components/studio-platform/plugins/org.wso2.integrationstudio.platform.ui/src/org/wso2/integrationstudio/platform/ui/utils/PlatformUIConstants.java
+++ b/components/studio-platform/plugins/org.wso2.integrationstudio.platform.ui/src/org/wso2/integrationstudio/platform/ui/utils/PlatformUIConstants.java
@@ -40,5 +40,5 @@ public class PlatformUIConstants {
     public static final String DOCKER_DEFAULT_BASE_REPOSITORY = "wso2/wso2mi";
     public static final String DOCKER_DEFAULT_BASE_TAG = "4.2.0";
     public static final String MI_DEPLOYMENT_TOML_TEMPLATE_VERSION = "4.2.0";
-
+    public static final String EMBEDDED_RUNTIME_DEFAULT_VERSION = "4.2.0";
 }


### PR DESCRIPTION
## Purpose
Add option to define runtime version for projects in the 'New Integration Project' Wizard
Fixes https://github.com/wso2/api-manager/issues/1841

## User Stories
The developer will have the option to define the runtime version when creating an Integration Project. By default, the version of the MI runtime shipped with the Studio will be set as the project’s runtime version.

![create_project](https://github.com/wso2/integration-studio/assets/18748929/fba17e55-2d4e-4f12-9d51-26b7d97442ee)
