### PR TITLE
Fix diagram view loading issue due to URL encoding in workspace

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.diagram/src/org/wso2/integrationstudio/gmf/esb/diagram/part/EsbDiagramEditorUtil.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.gmf.esb.diagram/src/org/wso2/integrationstudio/gmf/esb/diagram/part/EsbDiagramEditorUtil.java
@@ -229,9 +229,9 @@ public class EsbDiagramEditorUtil {
         Location instanceLoc = Platform.getInstanceLocation();
         String prefix = instanceLoc.getURL().toString() + RESOURCES_PATH + name;
         final Resource diagramResource = editingDomain.getResourceSet()
-                .createResource(URI.createURI(prefix.concat(".esb_diagram")));
+                .createResource(URI.createFileURI(prefix.concat(".esb_diagram")));
         final Resource modelResource = editingDomain.getResourceSet()
-                .createResource(URI.createURI(prefix.concat(".esb")));
+                .createResource(URI.createFileURI(prefix.concat(".esb")));
         editingDomain.getResourceSet().getResources().add(diagramResource);
         editingDomain.getResourceSet().getResources().add(modelResource);
         AbstractTransactionalCommand command = new AbstractTransactionalCommand(editingDomain,


### PR DESCRIPTION
## Purpose
IndexOutofBound error gets thrown from the IS if the workspace file path contains a space. This issue was due to the usage of `URI.createURI()` method to generate a file URI object. Having spaces, throw following exception and do not initialize design page data. Since design data page do not available, it throw IndexOutofBound exception.

```
org.eclipse.gmf.runtime.emf.core.util.Util.denormalizeURI(Util.java:164), 
org.eclipse.gmf.runtime.emf.core.resources.GMFResource.setURI(GMFResource.java:112), 
org.eclipse.gmf.runtime.emf.core.internal.resources.PathmapManager.denormalize(PathmapManager.java:819), org.eclipse.gmf.runtime.emf.core.internal.resources.PathmapManager.notifyChanged(PathmapManager.java:584), 
org.eclipse.emf.common.notify.impl.BasicNotifierImpl.eNotify(BasicNotifierImpl.java:424), 
org.eclipse.emf.common.notify.impl.NotifyingListImpl.dispatchNotification(NotifyingListImpl.java:261), 
org.eclipse.emf.common.notify.impl.NotifyingListImpl.addUnique(NotifyingListImpl.java:294), 
org.eclipse.emf.common.util.AbstractEList.add(AbstractEList.java:304), 
org.eclipse.emf.ecore.resource.impl.ResourceSetImpl.createResource(ResourceSetImpl.java:435), 
org.eclipse.emf.ecore.resource.impl.ResourceSetImpl.createResource(ResourceSetImpl.java:423), org.wso2.integrationstudio.gmf.esb.diagram.part.EsbDiagramEditorUtil.createResource(EsbDiagramEditorUtil.java:231), org.wso2.integrationstudio.gmf.esb.diagram.part.EsbDocumentProvider.setDocumentContent(EsbDocumentProvider.java:194), org.wso2.integrationstudio.gmf.esb.diagram.part.EsbDocumentProvider.createDocument(EsbDocumentProvider.java:98), org.wso2.integrationstudio.gmf.esb.diagram.part.EsbDocumentProvider.createElementInfo(EsbDocumentProvider.java:77), org.eclipse.gmf.runtime.diagram.ui.resources.editor.document.AbstractDocumentProvider.connect(AbstractDocumentProvider.java:388), org.eclipse.gmf.runtime.diagram.ui.resources.editor.parts.DiagramDocumentEditor.doSetInput(DiagramDocumentEditor.java:466), org.eclipse.gmf.runtime.diagram.ui.resources.editor.parts.DiagramDocumentEditor.setInput(DiagramDocumentEditor.java:429), 
org.eclipse.gef.ui.parts.GraphicalEditor.init(GraphicalEditor.java:346), 
org.eclipse.gmf.runtime.diagram.ui.parts.DiagramEditor.init(DiagramEditor.java:654), 
```

## Approach
Here, instead of `URI.createURI()`, we can use `URI.createFileURI()` method to generate URI object which handle special characters.

## Related issues
https://github.com/wso2/api-manager/issues/1828