### PR TITLE
Update soap-to-rest dependency to version 1.3

### DIFF
--- a/components/studio-platform/plugins/org.wso2.integrationstudio.kernel.libraries/.classpath
+++ b/components/studio-platform/plugins/org.wso2.integrationstudio.kernel.libraries/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry exported="true" kind="lib" path="lib/soaptorest-1.2-jar-with-dependencies.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/soaptorest-1.3-jar-with-dependencies.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/org.eclipse.emf.ecore_2.25.0.v20210816-0937.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/org.eclipse.gmf.runtime.notation_1.10.0.202004160913.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/commons-codec_1.4.0.wso2v1.jar"/>

--- a/components/studio-platform/plugins/org.wso2.integrationstudio.kernel.libraries/META-INF/MANIFEST.MF
+++ b/components/studio-platform/plugins/org.wso2.integrationstudio.kernel.libraries/META-INF/MANIFEST.MF
@@ -41,7 +41,7 @@ Bundle-ClassPath: lib/axiom-1.2.11.wso2v10.jar,
  lib/wsdl4j_1.6.2.wso2v4.jar,
  lib/org.eclipse.gmf.runtime.notation_1.10.0.202004160913.jar,
  lib/org.eclipse.emf.ecore_2.25.0.v20210816-0937.jar,
- lib/soaptorest-1.2-jar-with-dependencies.jar
+ lib/soaptorest-1.3-jar-with-dependencies.jar
 Export-Package: javax.activation,
  javax.wsdl;version="1.6.2.wso2v1",
  javax.wsdl.extensions;version="1.6.2.wso2v1",

--- a/components/studio-platform/plugins/org.wso2.integrationstudio.kernel.libraries/build.properties
+++ b/components/studio-platform/plugins/org.wso2.integrationstudio.kernel.libraries/build.properties
@@ -29,5 +29,5 @@ bin.includes = META-INF/,\
                lib/wsdl4j_1.6.2.wso2v4.jar,\
                lib/org.eclipse.gmf.runtime.notation_1.10.0.202004160913.jar,\
                lib/org.eclipse.emf.ecore_2.25.0.v20210816-0937.jar,\
-               lib/soaptorest-1.2-jar-with-dependencies.jar
+               lib/soaptorest-1.3-jar-with-dependencies.jar
 jars.compile.order = .


### PR DESCRIPTION
## Purpose
Update soap-to-rest dependency to version 1.3

## Related PR
https://github.com/wso2/soap-to-rest/pull/8