### PR TITLE
Save content only if it changed

### DIFF
--- a/components/studio-platform/plugins/org.wso2.integrationstudio.maven.multi.module/src/org/wso2/integrationstudio/maven/multi/module/editor/DistProjectEditorPage.java
+++ b/components/studio-platform/plugins/org.wso2.integrationstudio.maven.multi.module/src/org/wso2/integrationstudio/maven/multi/module/editor/DistProjectEditorPage.java
@@ -823,10 +823,18 @@ public class DistProjectEditorPage extends FormPage implements IResourceDeltaVis
                             return;
                         }
                         createTreeContent();
-                        txtVersion.setText(getVersion());
-                        txtArtifactId.setText(getArtifactId());
-                        txtDescription.setText(getDescription());
-                        txtGroupId.setText(getGroupId());
+                        if (!getVersion().equals(txtVersion.getText())) {
+                            txtVersion.setText(getVersion());
+                        }
+                        if (!getArtifactId().equals(txtArtifactId.getText())) {
+                            txtArtifactId.setText(getArtifactId());
+                        }
+                        if (!getDescription().equals(txtDescription.getText())) {
+                            txtDescription.setText(getDescription());
+                        }
+                        if (!getGroupId().equals(txtGroupId.getText())) {
+                            txtGroupId.setText(getGroupId());
+                        }   
                     }
                 });
             }


### PR DESCRIPTION
### Problem
When a new artifact is added or deleted from the Integration Studio, root pom.xml is always marked with a start which represents it contains modifications. But, removing or adding artifacts actually does not do any modification to the root pom file. Therefore, adding or removing artifacts should not do any modification to the root pom file.

### Solution
In the current implementation, we always update the version, id, description, and group id every time if there are artifact addition or deletion. Save content only if there are changes. Otherwise, ignore it.