### PR TITLE
Fix inconsistent value in design and source views for field 'type' in dataservices's queries

### DIFF
--- a/components/dss-tools/plugins/org.wso2.integrationstudio.ds.editor/DSSEditor/index.html
+++ b/components/dss-tools/plugins/org.wso2.integrationstudio.ds.editor/DSSEditor/index.html
@@ -1422,7 +1422,7 @@
                                     id="q-im-inout-select" name="q-im-inout-select">
                                     <option value="IN" selected="">IN</option>
                                     <option value="OUT">OUT</option>
-                                    <option value="IN-OUT">INOUT</option>
+                                    <option value="INOUT">INOUT</option>
                                 </select></div>
                         </div>
                         <div class="form-group">


### PR DESCRIPTION
## Purpose
The form view displays the type as "INOUT". But, it is saved as "IN-OUT" in the source view. This PR fixes this inconsistency.

