### PR TITLE
Revert "Add class name in custom inbound endpoint"

### DIFF
--- a/components/esb-tools/plugins/org.wso2.integrationstudio.artifact.inboundendpoint/src/org/wso2/integrationstudio/artifact/inboundendpoint/ui/wizard/InboundEndpointProjectCreationWizard.java
+++ b/components/esb-tools/plugins/org.wso2.integrationstudio.artifact.inboundendpoint/src/org/wso2/integrationstudio/artifact/inboundendpoint/ui/wizard/InboundEndpointProjectCreationWizard.java
@@ -259,7 +259,7 @@ public class InboundEndpointProjectCreationWizard extends AbstractWSO2ProjectCre
 			inboundEndpoint.setName(ieModel.getName());
 			
 			if(ieModel.getProtocol().equals(CUSTOM)){
-				inboundEndpoint.setClassImpl("org.wso2.carbon.inbound.kafka.KafkaMessageConsumer");
+				inboundEndpoint.setClassImpl("org.wso2.sample.inbound.CustomClass");
 			} else {
 				inboundEndpoint.setProtocol(ieModel.getProtocol());
 				if(ieModel.getProtocol().equals(KAFKA)){


### PR DESCRIPTION
Reverts wso2/integration-studio#1010

No need to add Kafka values by default.