### PR TITLE
Break the for loop in DSS queries list when populating the resource table

### DIFF
--- a/components/dss-tools/plugins/org.wso2.integrationstudio.ds.editor/DSSEditor/assets/js/data-handler.js
+++ b/components/dss-tools/plugins/org.wso2.integrationstudio.ds.editor/DSSEditor/assets/js/data-handler.js
@@ -1625,6 +1625,7 @@ function populateResourceParameterTable(root, queryId) {
 				var paramName = params[j].getAttribute("name");
 				items.push(paramName);
 			}
+			break;
 		}
     }
 


### PR DESCRIPTION
## Purpose

When there are multiple input mapping in a DSS query, the resource edit button is not working as we keep iterating the query list. To fix this we need to break the for loop in DSS queries list when populating the resource table.